### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/behave-tests.yml
+++ b/.github/workflows/behave-tests.yml
@@ -1,5 +1,7 @@
 # .github/workflows/behave-tests.yml
 name: Behave Acceptance Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jondavid-black/yaml-tools/security/code-scanning/1](https://github.com/jondavid-black/yaml-tools/security/code-scanning/1)

To fix this problem, add an explicit `permissions:` block to the workflow YAML. The block should be placed either at the root level (to apply the restricted permissions for all jobs by default) or within the job's configuration (for granular control). Since the workflow’s jobs only check out the repository and run tests, only the `contents: read` permission is required. Therefore, add `permissions: contents: read` at the root level of the workflow YAML, directly below the `name:` property and before the `on:` trigger (as recommended by GitHub documentation).

No imports or special methods are needed; this is a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
