### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 # .github/workflows/ci.yml
 name: YASL CI/CD
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jondavid-black/yaml-tools/security/code-scanning/2](https://github.com/jondavid-black/yaml-tools/security/code-scanning/2)

To fix this issue, you should explicitly set the `permissions` key to restrict what the job's `GITHUB_TOKEN` can do. Since this workflow only checks out code and runs tests and tools, read-only access is sufficient. The minimal and correct change is to add `permissions: contents: read` at the top-level scope (after the `name:` block and before `on:`), applying to all jobs in the workflow unless specifically overridden. This follows GitHub's guidance for least privilege and satisfies security scanning tools.

- Edit the file `.github/workflows/ci.yml`.
- Insert the following block after `name: YASL CI/CD`, before `on:`.
- No additional imports or tool changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
