### PR TITLE
Extract Namespace

### DIFF
--- a/features/data/address.yasl
+++ b/features/data/address.yasl
@@ -1,21 +1,22 @@
-types:
-  address:
-    namespace: acme
-    description: Information about an address.
-    properties:
-      street:
-        type: str
-        description: The street address.
-        required: true
-      city:
-        type: str
-        description: The city.
-        required: false
-      zip_code:
-        type: PositiveInt
-        description: The postal code.
-        required: true
-      other:
-        type: str[]
-        description: The name by which the address is known.
-        required: true
+definitions:
+  acme:
+    types:
+      address:
+        description: Information about an address.
+        properties:
+          street:
+            type: str
+            description: The street address.
+            required: true
+          city:
+            type: str
+            description: The city.
+            required: false
+          zip_code:
+            type: PositiveInt
+            description: The postal code.
+            required: true
+          other:
+            type: str[]
+            description: The name by which the address is known.
+            required: true

--- a/features/data/ambiguous_ns/todo01.yasl
+++ b/features/data/ambiguous_ns/todo01.yasl
@@ -1,33 +1,34 @@
 imports:
   - ./todo02.yasl
-types:
-  task:
-    description: A thing to do.
-    namespace: main
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
-        
-  task_list:
-    description: A list of tasks to complete.
-    namespace: other
-    properties:
-      favorite_task:
-        type: task
-        description: The task I like the most.
-        required: false
+definitions:
+  main:
+    types:
+      task:
+        description: A thing to do.
+        properties:
+          description:
+            type: str
+            description: A description of the task.
+            required: true
+          owner:
+            type: str
+            description: The person responsible for the task.
+            required: false
+          complete:
+            type: bool
+            description: Is the task finished? True if yes, false if no.
+            required: true
+            default: false
+  other:
+    types:        
       task_list:
-        type: map[str, task]
-        description: A list of tasks to do.
-        required: true
+        description: A list of tasks to complete.
+        properties:
+          favorite_task:
+            type: task
+            description: The task I like the most.
+            required: false
+          task_list:
+            type: map[str, task]
+            description: A list of tasks to do.
+            required: true

--- a/features/data/ambiguous_ns/todo02.yasl
+++ b/features/data/ambiguous_ns/todo02.yasl
@@ -1,18 +1,19 @@
-types:
-  task:
-    description: A thing to do.
-    namespace: other
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
+definitions:
+  other:
+    types:
+      task:
+        description: A thing to do.
+        properties:
+          description:
+            type: str
+            description: A description of the task.
+            required: true
+          owner:
+            type: str
+            description: The person responsible for the task.
+            required: false
+          complete:
+            type: bool
+            description: Is the task finished? True if yes, false if no.
+            required: true
+            default: false

--- a/features/data/customer_basic.yasl
+++ b/features/data/customer_basic.yasl
@@ -1,71 +1,68 @@
-enums:
-  customer_status:
-    namespace: acme
-    description: The status of the customer.
-    values:
-      - active
-      - inactive
-types:
-  customer:
-    namespace: acme
-    description: Information about a customer.
-    properties:
-      name:
-        type: str
-        description: The customer's name.
-        required: true
-        unique: true
-      age:
-        type: int
-        description: The customer's age.
-        required: false
-      email:
-        type: str
-        description:  The customer's email address.
-        required: true
-      status:
-        type: customer_status
-        namespace: acme
-        description: The customer's status.
-        required: true
-  customer_list:
-    namespace: acme
-    description: A list of customers.
-    properties:
-      customers:
-        type: customer[]
+definitions:
+  acme:
+    description: Acme Corporation schema definitions.
+    enums:
+      customer_status:
+          description: The status of the customer.
+          values:
+              - active
+              - inactive
+    types:
+      customer:
         description: Information about a customer.
-        list_min: 2
-        list_max: 3
-  account:
-    namespace: acme
-    description: Information about an account.
-    properties:
-      id:
-        type: str
-        description: The unique identifier for the account.
-        required: true
-      account_rep:
-        type: str
-        description: The name of the account representative.
-        required: true
-      customer_name:
-        type: ref[customer.name]
-        description: The name of the customer associated with the account.
-        required: true
-  business:
-    namespace: acme
-    description: A list of accounts.
-    properties:
-      business_name:
-        type: str
-        description: The name of the business.
-        required: true
-      customers:
-        type: customer[]
-        description: Information about a list of customers.
-        required: true
-      accounts:
-        type: account[]
+        properties:
+          name:
+            type: str
+            description: The customer's name.
+            required: true
+            unique: true
+          age:
+            type: int
+            description: The customer's age.
+            required: false
+          email:
+            type: str
+            description:  The customer's email address.
+            required: true
+          status:
+            type: customer_status
+            description: The customer's status.
+            required: true
+      customer_list:
+        description: A list of customers.
+        properties:
+          customers:
+            type: acme.customer[]
+            description: Information about a customer.
+            list_min: 2
+            list_max: 3
+      account:
         description: Information about an account.
-        required: true
+        properties:
+          id:
+            type: str
+            description: The unique identifier for the account.
+            required: true
+          account_rep:
+            type: str
+            description: The name of the account representative.
+            required: true
+          customer_name:
+            type: ref[acme.customer.name]
+            description: The name of the customer associated with the account.
+            required: true
+      business:
+        description: A list of accounts.
+        properties:
+          business_name:
+            type: str
+            description: The name of the business.
+            required: true
+          customers:
+            type: acme.customer[]
+            description: Information about a list of customers.
+            required: true
+          accounts:
+            type: acme.account[]
+            description: Information about an account.
+            required: true

--- a/features/data/dir_test/shape.yasl
+++ b/features/data/dir_test/shape.yasl
@@ -1,76 +1,76 @@
-types:
-  shape:
-    namespace: acme
-    description: Information about a shape.
-    properties:
-      name:
-        type: str
-        description: The name of the shape.
-        required: true
-      type:
-        type: ShapeType
+definitions:
+  acme:
+    types:
+      shape:
+        description: Information about a shape.
+        properties:
+          name:
+            type: str
+            description: The name of the shape.
+            required: true
+          type:
+            type: ShapeType
+            description: The type of shape.
+            required: true
+          radius:
+            type: float
+            description: The radius of the circle.
+            required: false
+            gt: 0
+          side_length:
+            type: float
+            description: The length of the side of the square or triangle.
+            required: false
+            gt: 0
+          color:
+            type: str
+            description: The color of the shape.
+            required: false
+          colour:
+            type: str
+            description: The color of the shape (British spelling).
+            required: false
+          location:
+            type: str
+            description: The location of the shape.
+            required: false
+          orientation:
+            type: str
+            description: The orientation of the shape.
+            required: false
+        validators:
+          only_one:
+            - color
+            - colour
+          at_least_one:
+            - location
+            - orientation
+          if_then:
+            - eval: type
+              value: 
+              - circle
+              present:
+                - radius
+              absent:
+                - side_length
+            - eval: type
+              value: 
+                - square
+              present:
+                - side_length
+              absent:
+                - radius
+            - eval: type
+              value: 
+                - triangle
+              present:
+                - side_length
+              absent:
+                - radius
+    enums:
+      ShapeType:
         description: The type of shape.
-        required: true
-      radius:
-        type: float
-        description: The radius of the circle.
-        required: false
-        gt: 0
-      side_length:
-        type: float
-        description: The length of the side of the square or triangle.
-        required: false
-        gt: 0
-      color:
-        type: str
-        description: The color of the shape.
-        required: false
-      colour:
-        type: str
-        description: The color of the shape (British spelling).
-        required: false
-      location:
-        type: str
-        description: The location of the shape.
-        required: false
-      orientation:
-        type: str
-        description: The orientation of the shape.
-        required: false
-    validators:
-      only_one:
-        - color
-        - colour
-      at_least_one:
-        - location
-        - orientation
-      if_then:
-        - eval: type
-          value: 
-           - circle
-          present:
-            - radius
-          absent:
-            - side_length
-        - eval: type
-          value: 
-            - square
-          present:
-            - side_length
-          absent:
-            - radius
-        - eval: type
-          value: 
-            - triangle
-          present:
-            - side_length
-          absent:
-            - radius
-enums:
-  ShapeType:
-    namespace: acme
-    description: The type of shape.
-    values:
-      - circle
-      - square
-      - triangle
+        values:
+          - circle
+          - square
+          - triangle

--- a/features/data/dir_test/thing.yasl
+++ b/features/data/dir_test/thing.yasl
@@ -1,198 +1,200 @@
-types:
-  thing:
-    namespace: acme
-    description: Information about a thing.
-    properties:
-      id:
-        type: str
-        description: The unique identifier for the thing.
-        required: true
-      strict_bool:
-        type: StrictBool
-        description: A strict boolean value.
-        required: false
-      positive_int:
-        type: PositiveInt
-        description: A positive integer value.
-        required: false
-      negative_int:
-        type: NegativeInt
-        description: A negative integer value.
-        required: false
-      non_positive_int:
-        type: NonPositiveInt
-        description: A non-positive integer value.
-        required: false
-      non_negative_int:
-        type: NonNegativeInt
-        description: A non-negative integer value.
-        required: false
-      strict_int:
-        type: StrictInt
-        description: A strict integer value.
-        required: false
-      positive_float:
-        type: PositiveFloat
-        description: A positive float value.
-        required: false
-      negative_float:
-        type: NegativeFloat
-        description: A negative float value.
-        required: false
-      non_positive_float:
-        type: NonPositiveFloat
-        description: A non-positive float value.
-        required: false
-      non_negative_float:
-        type: NonNegativeFloat
-        description: A non-negative float value.
-        required: false
-      strict_float:
-        type: StrictFloat
-        description: A strict float value.
-        required: false
-      finite_float:
-        type: FiniteFloat
-        description: A finite float value (not NaN or infinite).
-        required: false
-      strict_str:
-        type: StrictStr
-        description: A strict string value.
-        required: false
-      uuid1:
-        type: UUID1
-        description: A UUID version 1.
-        required: false
-      uuid3:
-        type: UUID3
-        description: A UUID version 3.
-        required: false
-      uuid4:
-        type: UUID4
-        description: A UUID version 4.
-        required: false
-      uuid5:
-        type: UUID5
-        description: A UUID version 5.
-        required: false
-      uuid6:
-        type: UUID6
-        description: A UUID version 6.
-        required: false
-      uuid7:
-        type: UUID7
-        description: A UUID version 7.
-        required: false
-      uuid8:
-        type: UUID8
-        description: A UUID version 8.
-        required: false
-      file_path:
-        type: FilePath
-        description: A valid file path.
-        required: false
-      directory_path:
-        type: DirectoryPath
-        description: A valid directory path.
-        required: false
-      base64_bytes:
-        type: Base64Bytes
-        description: A base64 encoded byte string.
-        required: false
-      base64_str:
-        type: Base64Str
-        description: A base64 encoded string.
-        required: false
-      base64_url_bytes:
-        type: Base64UrlBytes
-        description: A base64 URL-safe encoded byte string.
-        required: false
-      base64_url_str:
-        type: Base64UrlStr
-        description: A base64 URL-safe encoded string.
-        required: false
-      any_url:
-        type: AnyUrl
-        description: Any valid URL.
-        required: false
-      any_http_url:
-        type: AnyHttpUrl
-        description: Any valid HTTP or HTTPS URL.
-        required: false
-      http_url:
-        type: HttpUrl
-        description: A valid HTTP or HTTPS URL.
-        required: false
-      any_websocket_url:
-        type: AnyWebsocketUrl
-        description: Any valid WebSocket or secure WebSocket URL.
-        required: false
-      websocket_url:
-        type: WebsocketUrl
-        description: A valid WebSocket or secure WebSocket URL.
-        required: false
-      file_url:
-        type: FileUrl
-        description: A valid file URL.
-        required: false
-      ftp_url:
-        type: FtpUrl
-        description: A valid FTP or FTPS URL.
-        required: false
-      postgres_dsn:
-        type: PostgresDsn
-        description: A valid PostgreSQL DSN.
-        required: false
-      cockroach_dsn:
-        type: CockroachDsn
-        description: A valid CockroachDB DSN.
-        required: false
-      amqp_dsn:
-        type: AmqpDsn
-        description: A valid AMQP DSN.
-        required: false
-      redis_dsn:
-        type: RedisDsn
-        description: A valid Redis DSN.
-        required: false
-      mongo_dsn:
-        type: MongoDsn
-        description: A valid MongoDB DSN.
-        required: false
-      kafka_dsn:
-        type: KafkaDsn
-        description: A valid Kafka DSN.
-        required: false
-      nats_dsn:
-        type: NatsDsn
-        description: A valid NATS DSN.
-        required: false
-      mysql_dsn:
-        type: MySQLDsn
-        description: A valid MySQL DSN.
-        required: false
-      mariadb_dsn:
-        type: MariaDBDsn
-        description: A valid MariaDB DSN.
-        required: false
-      clickhouse_dsn:
-        type: ClickHouseDsn
-        description: A valid ClickHouse DSN.
-        required: false
-      snowflake_dsn:
-        type: SnowflakeDsn
-        description: A valid Snowflake DSN.
-        required: false
-      email_str:
-        type: EmailStr
-        description: A valid email address.
-        required: false
-      name_email:
-        type: NameEmail
-        description: A valid name and email address.
-        required: false
-      ipvany_address:
-        type: IPvAnyAddress
-        description: A valid IPv4 or IPv6 address.
-        required: false
-      
+definitions:
+  acme:
+    types:
+      thing:
+        namespace: acme
+        description: Information about a thing.
+        properties:
+          id:
+            type: str
+            description: The unique identifier for the thing.
+            required: true
+          strict_bool:
+            type: StrictBool
+            description: A strict boolean value.
+            required: false
+          positive_int:
+            type: PositiveInt
+            description: A positive integer value.
+            required: false
+          negative_int:
+            type: NegativeInt
+            description: A negative integer value.
+            required: false
+          non_positive_int:
+            type: NonPositiveInt
+            description: A non-positive integer value.
+            required: false
+          non_negative_int:
+            type: NonNegativeInt
+            description: A non-negative integer value.
+            required: false
+          strict_int:
+            type: StrictInt
+            description: A strict integer value.
+            required: false
+          positive_float:
+            type: PositiveFloat
+            description: A positive float value.
+            required: false
+          negative_float:
+            type: NegativeFloat
+            description: A negative float value.
+            required: false
+          non_positive_float:
+            type: NonPositiveFloat
+            description: A non-positive float value.
+            required: false
+          non_negative_float:
+            type: NonNegativeFloat
+            description: A non-negative float value.
+            required: false
+          strict_float:
+            type: StrictFloat
+            description: A strict float value.
+            required: false
+          finite_float:
+            type: FiniteFloat
+            description: A finite float value (not NaN or infinite).
+            required: false
+          strict_str:
+            type: StrictStr
+            description: A strict string value.
+            required: false
+          uuid1:
+            type: UUID1
+            description: A UUID version 1.
+            required: false
+          uuid3:
+            type: UUID3
+            description: A UUID version 3.
+            required: false
+          uuid4:
+            type: UUID4
+            description: A UUID version 4.
+            required: false
+          uuid5:
+            type: UUID5
+            description: A UUID version 5.
+            required: false
+          uuid6:
+            type: UUID6
+            description: A UUID version 6.
+            required: false
+          uuid7:
+            type: UUID7
+            description: A UUID version 7.
+            required: false
+          uuid8:
+            type: UUID8
+            description: A UUID version 8.
+            required: false
+          file_path:
+            type: FilePath
+            description: A valid file path.
+            required: false
+          directory_path:
+            type: DirectoryPath
+            description: A valid directory path.
+            required: false
+          base64_bytes:
+            type: Base64Bytes
+            description: A base64 encoded byte string.
+            required: false
+          base64_str:
+            type: Base64Str
+            description: A base64 encoded string.
+            required: false
+          base64_url_bytes:
+            type: Base64UrlBytes
+            description: A base64 URL-safe encoded byte string.
+            required: false
+          base64_url_str:
+            type: Base64UrlStr
+            description: A base64 URL-safe encoded string.
+            required: false
+          any_url:
+            type: AnyUrl
+            description: Any valid URL.
+            required: false
+          any_http_url:
+            type: AnyHttpUrl
+            description: Any valid HTTP or HTTPS URL.
+            required: false
+          http_url:
+            type: HttpUrl
+            description: A valid HTTP or HTTPS URL.
+            required: false
+          any_websocket_url:
+            type: AnyWebsocketUrl
+            description: Any valid WebSocket or secure WebSocket URL.
+            required: false
+          websocket_url:
+            type: WebsocketUrl
+            description: A valid WebSocket or secure WebSocket URL.
+            required: false
+          file_url:
+            type: FileUrl
+            description: A valid file URL.
+            required: false
+          ftp_url:
+            type: FtpUrl
+            description: A valid FTP or FTPS URL.
+            required: false
+          postgres_dsn:
+            type: PostgresDsn
+            description: A valid PostgreSQL DSN.
+            required: false
+          cockroach_dsn:
+            type: CockroachDsn
+            description: A valid CockroachDB DSN.
+            required: false
+          amqp_dsn:
+            type: AmqpDsn
+            description: A valid AMQP DSN.
+            required: false
+          redis_dsn:
+            type: RedisDsn
+            description: A valid Redis DSN.
+            required: false
+          mongo_dsn:
+            type: MongoDsn
+            description: A valid MongoDB DSN.
+            required: false
+          kafka_dsn:
+            type: KafkaDsn
+            description: A valid Kafka DSN.
+            required: false
+          nats_dsn:
+            type: NatsDsn
+            description: A valid NATS DSN.
+            required: false
+          mysql_dsn:
+            type: MySQLDsn
+            description: A valid MySQL DSN.
+            required: false
+          mariadb_dsn:
+            type: MariaDBDsn
+            description: A valid MariaDB DSN.
+            required: false
+          clickhouse_dsn:
+            type: ClickHouseDsn
+            description: A valid ClickHouse DSN.
+            required: false
+          snowflake_dsn:
+            type: SnowflakeDsn
+            description: A valid Snowflake DSN.
+            required: false
+          email_str:
+            type: EmailStr
+            description: A valid email address.
+            required: false
+          name_email:
+            type: NameEmail
+            description: A valid name and email address.
+            required: false
+          ipvany_address:
+            type: IPvAnyAddress
+            description: A valid IPv4 or IPv6 address.
+            required: false
+          

--- a/features/data/person.yasl
+++ b/features/data/person.yasl
@@ -1,65 +1,66 @@
 imports:
   - ./address.yasl
-types:
-  person:
-    namespace: acme
-    description: Information about a person.
-    properties:
-      name:
-        type: str
-        description: The person's name.
-        required: true
-      age:
-        type: int
-        description: The person's age.
-        required: true
-        ge: 18
-        lt: 125
-        whole_number: true
-        exclude:
-          - 65
-      birthday:
-        type: date
-        description: The person's birthday.
-        required: false
-        after: "1900-01-01"
-        before: "2050-12-31"
-      favorite_time:
-        type: time
-        description: The person's favorite time of day.
-        required: false
-        after: "11:00:00"
-        before: "15:00:00"
-      office:
-        type: any
-        description: The person's office location.
-        required: false
-        any_of:
-          - int
-          - bool
-      bio:
-        type: path
-        description: Path to a file containing the person's biography.
-        required: false
-        path_exists: false
-        is_file: true
-        file_ext:
-          - txt
-          - .md
-      home_directory:
-        type: path
-        description: Path to the person's home directory.
-        required: false
-        path_exists: true
-        is_dir: true
-      website:
-        type: url
-        description: The person's website.
-        required: false
-        url_protocols:
-          - http
-          - https
-      address:
-        type: address
-        description: The person's address.
-        required: false
+definitions:
+  acme:
+    types:
+      person:
+        description: Information about a person.
+        properties:
+          name:
+            type: str
+            description: The person's name.
+            required: true
+          age:
+            type: int
+            description: The person's age.
+            required: true
+            ge: 18
+            lt: 125
+            whole_number: true
+            exclude:
+              - 65
+          birthday:
+            type: date
+            description: The person's birthday.
+            required: false
+            after: "1900-01-01"
+            before: "2050-12-31"
+          favorite_time:
+            type: time
+            description: The person's favorite time of day.
+            required: false
+            after: "11:00:00"
+            before: "15:00:00"
+          office:
+            type: any
+            description: The person's office location.
+            required: false
+            any_of:
+              - int
+              - bool
+          bio:
+            type: path
+            description: Path to a file containing the person's biography.
+            required: false
+            path_exists: false
+            is_file: true
+            file_ext:
+              - txt
+              - .md
+          home_directory:
+            type: path
+            description: Path to the person's home directory.
+            required: false
+            path_exists: true
+            is_dir: true
+          website:
+            type: url
+            description: The person's website.
+            required: false
+            url_protocols:
+              - http
+              - https
+          address:
+            type: address
+            description: The person's address.
+            required: false

--- a/features/data/person_list.yasl
+++ b/features/data/person_list.yasl
@@ -1,11 +1,12 @@
 imports:
   - ./person.yasl
-types:
-  person_list:
-    namespace: acme
-    description: A list of persons.
-    properties:
-      people:
-        type: person[]
+definitions:
+  acme:
+    types:
+      person_list:
         description: A list of persons.
-        required: true
+        properties:
+          people:
+            type: person[]
+            description: A list of persons.
+            required: true

--- a/features/data/shape.yaml
+++ b/features/data/shape.yaml
@@ -1,7 +1,5 @@
 name: bob
 type: square
-# radius: 5.0
 side_length: 10.0
 color: red
 location: top-left
-# orientation: centered

--- a/features/data/shape.yasl
+++ b/features/data/shape.yasl
@@ -1,76 +1,70 @@
-types:
-  shape:
-    namespace: acme
-    description: Information about a shape.
-    properties:
-      name:
-        type: str
-        description: The name of the shape.
-        required: true
-      type:
-        type: ShapeType
+definitions:
+  acme:
+    types:
+      shape:
+        description: Information about a shape.
+        properties:
+          name:
+              type: str
+              description: The name of the shape.
+              required: true
+          type:
+              type: ShapeType
+              description: The type of shape.
+              required: true
+          radius:
+              type: float
+              description: The radius of the circle.
+              required: false
+              gt: 0
+          side_length:
+              type: float
+              description: The length of the side of the square or triangle.
+              required: false
+              gt: 0
+          color:
+              type: str
+              description: The color of the shape.
+              required: false
+          colour:
+              type: str
+              description: The color of the shape (British spelling).
+              required: false
+          location:
+              type: str
+              description: The location of the shape.
+              required: false
+          orientation:
+              type: str
+              description: The orientation of the shape.
+              required: false
+        validators:
+          only_one:
+            - color
+            - colour
+          at_least_one:
+            - location
+            - orientation
+          if_then:
+            - eval: type
+              value: 
+                - circle
+              present:
+                - radius
+              absent:
+                - side_length
+            - eval: type
+              value: 
+                - square
+                - triangle
+              present:
+                - side_length
+              absent:
+                - radius
+    enums:
+      ShapeType:
         description: The type of shape.
-        required: true
-      radius:
-        type: float
-        description: The radius of the circle.
-        required: false
-        gt: 0
-      side_length:
-        type: float
-        description: The length of the side of the square or triangle.
-        required: false
-        gt: 0
-      color:
-        type: str
-        description: The color of the shape.
-        required: false
-      colour:
-        type: str
-        description: The color of the shape (British spelling).
-        required: false
-      location:
-        type: str
-        description: The location of the shape.
-        required: false
-      orientation:
-        type: str
-        description: The orientation of the shape.
-        required: false
-    validators:
-      only_one:
-        - color
-        - colour
-      at_least_one:
-        - location
-        - orientation
-      if_then:
-        - eval: type
-          value: 
-           - circle
-          present:
-            - radius
-          absent:
-            - side_length
-        - eval: type
-          value: 
-            - square
-          present:
-            - side_length
-          absent:
-            - radius
-        - eval: type
-          value: 
-            - triangle
-          present:
-            - side_length
-          absent:
-            - radius
-enums:
-  ShapeType:
-    namespace: acme
-    description: The type of shape.
-    values:
-      - circle
-      - square
-      - triangle
+        values:
+          - circle
+          - square
+          - triangle

--- a/features/data/thing.yasl
+++ b/features/data/thing.yasl
@@ -1,198 +1,199 @@
-types:
-  thing:
-    namespace: acme
-    description: Information about a thing.
-    properties:
-      id:
-        type: str
-        description: The unique identifier for the thing.
-        required: true
-      strict_bool:
-        type: StrictBool
-        description: A strict boolean value.
-        required: false
-      positive_int:
-        type: PositiveInt
-        description: A positive integer value.
-        required: false
-      negative_int:
-        type: NegativeInt
-        description: A negative integer value.
-        required: false
-      non_positive_int:
-        type: NonPositiveInt
-        description: A non-positive integer value.
-        required: false
-      non_negative_int:
-        type: NonNegativeInt
-        description: A non-negative integer value.
-        required: false
-      strict_int:
-        type: StrictInt
-        description: A strict integer value.
-        required: false
-      positive_float:
-        type: PositiveFloat
-        description: A positive float value.
-        required: false
-      negative_float:
-        type: NegativeFloat
-        description: A negative float value.
-        required: false
-      non_positive_float:
-        type: NonPositiveFloat
-        description: A non-positive float value.
-        required: false
-      non_negative_float:
-        type: NonNegativeFloat
-        description: A non-negative float value.
-        required: false
-      strict_float:
-        type: StrictFloat
-        description: A strict float value.
-        required: false
-      finite_float:
-        type: FiniteFloat
-        description: A finite float value (not NaN or infinite).
-        required: false
-      strict_str:
-        type: StrictStr
-        description: A strict string value.
-        required: false
-      uuid1:
-        type: UUID1
-        description: A UUID version 1.
-        required: false
-      uuid3:
-        type: UUID3
-        description: A UUID version 3.
-        required: false
-      uuid4:
-        type: UUID4
-        description: A UUID version 4.
-        required: false
-      uuid5:
-        type: UUID5
-        description: A UUID version 5.
-        required: false
-      uuid6:
-        type: UUID6
-        description: A UUID version 6.
-        required: false
-      uuid7:
-        type: UUID7
-        description: A UUID version 7.
-        required: false
-      uuid8:
-        type: UUID8
-        description: A UUID version 8.
-        required: false
-      file_path:
-        type: FilePath
-        description: A valid file path.
-        required: false
-      directory_path:
-        type: DirectoryPath
-        description: A valid directory path.
-        required: false
-      base64_bytes:
-        type: Base64Bytes
-        description: A base64 encoded byte string.
-        required: false
-      base64_str:
-        type: Base64Str
-        description: A base64 encoded string.
-        required: false
-      base64_url_bytes:
-        type: Base64UrlBytes
-        description: A base64 URL-safe encoded byte string.
-        required: false
-      base64_url_str:
-        type: Base64UrlStr
-        description: A base64 URL-safe encoded string.
-        required: false
-      any_url:
-        type: AnyUrl
-        description: Any valid URL.
-        required: false
-      any_http_url:
-        type: AnyHttpUrl
-        description: Any valid HTTP or HTTPS URL.
-        required: false
-      http_url:
-        type: HttpUrl
-        description: A valid HTTP or HTTPS URL.
-        required: false
-      any_websocket_url:
-        type: AnyWebsocketUrl
-        description: Any valid WebSocket or secure WebSocket URL.
-        required: false
-      websocket_url:
-        type: WebsocketUrl
-        description: A valid WebSocket or secure WebSocket URL.
-        required: false
-      file_url:
-        type: FileUrl
-        description: A valid file URL.
-        required: false
-      ftp_url:
-        type: FtpUrl
-        description: A valid FTP or FTPS URL.
-        required: false
-      postgres_dsn:
-        type: PostgresDsn
-        description: A valid PostgreSQL DSN.
-        required: false
-      cockroach_dsn:
-        type: CockroachDsn
-        description: A valid CockroachDB DSN.
-        required: false
-      amqp_dsn:
-        type: AmqpDsn
-        description: A valid AMQP DSN.
-        required: false
-      redis_dsn:
-        type: RedisDsn
-        description: A valid Redis DSN.
-        required: false
-      mongo_dsn:
-        type: MongoDsn
-        description: A valid MongoDB DSN.
-        required: false
-      kafka_dsn:
-        type: KafkaDsn
-        description: A valid Kafka DSN.
-        required: false
-      nats_dsn:
-        type: NatsDsn
-        description: A valid NATS DSN.
-        required: false
-      mysql_dsn:
-        type: MySQLDsn
-        description: A valid MySQL DSN.
-        required: false
-      mariadb_dsn:
-        type: MariaDBDsn
-        description: A valid MariaDB DSN.
-        required: false
-      clickhouse_dsn:
-        type: ClickHouseDsn
-        description: A valid ClickHouse DSN.
-        required: false
-      snowflake_dsn:
-        type: SnowflakeDsn
-        description: A valid Snowflake DSN.
-        required: false
-      email_str:
-        type: EmailStr
-        description: A valid email address.
-        required: false
-      name_email:
-        type: NameEmail
-        description: A valid name and email address.
-        required: false
-      ipvany_address:
-        type: IPvAnyAddress
-        description: A valid IPv4 or IPv6 address.
-        required: false
+definitions:
+  acme:
+    types:
+      thing:
+        description: Information about a thing.
+        properties:
+          id:
+            type: str
+            description: The unique identifier for the thing.
+            required: true
+          strict_bool:
+            type: StrictBool
+            description: A strict boolean value.
+            required: false
+          positive_int:
+            type: PositiveInt
+            description: A positive integer value.
+            required: false
+          negative_int:
+            type: NegativeInt
+            description: A negative integer value.
+            required: false
+          non_positive_int:
+            type: NonPositiveInt
+            description: A non-positive integer value.
+            required: false
+          non_negative_int:
+            type: NonNegativeInt
+            description: A non-negative integer value.
+            required: false
+          strict_int:
+            type: StrictInt
+            description: A strict integer value.
+            required: false
+          positive_float:
+            type: PositiveFloat
+            description: A positive float value.
+            required: false
+          negative_float:
+            type: NegativeFloat
+            description: A negative float value.
+            required: false
+          non_positive_float:
+            type: NonPositiveFloat
+            description: A non-positive float value.
+            required: false
+          non_negative_float:
+            type: NonNegativeFloat
+            description: A non-negative float value.
+            required: false
+          strict_float:
+            type: StrictFloat
+            description: A strict float value.
+            required: false
+          finite_float:
+            type: FiniteFloat
+            description: A finite float value (not NaN or infinite).
+            required: false
+          strict_str:
+            type: StrictStr
+            description: A strict string value.
+            required: false
+          uuid1:
+            type: UUID1
+            description: A UUID version 1.
+            required: false
+          uuid3:
+            type: UUID3
+            description: A UUID version 3.
+            required: false
+          uuid4:
+            type: UUID4
+            description: A UUID version 4.
+            required: false
+          uuid5:
+            type: UUID5
+            description: A UUID version 5.
+            required: false
+          uuid6:
+            type: UUID6
+            description: A UUID version 6.
+            required: false
+          uuid7:
+            type: UUID7
+            description: A UUID version 7.
+            required: false
+          uuid8:
+            type: UUID8
+            description: A UUID version 8.
+            required: false
+          file_path:
+            type: FilePath
+            description: A valid file path.
+            required: false
+          directory_path:
+            type: DirectoryPath
+            description: A valid directory path.
+            required: false
+          base64_bytes:
+            type: Base64Bytes
+            description: A base64 encoded byte string.
+            required: false
+          base64_str:
+            type: Base64Str
+            description: A base64 encoded string.
+            required: false
+          base64_url_bytes:
+            type: Base64UrlBytes
+            description: A base64 URL-safe encoded byte string.
+            required: false
+          base64_url_str:
+            type: Base64UrlStr
+            description: A base64 URL-safe encoded string.
+            required: false
+          any_url:
+            type: AnyUrl
+            description: Any valid URL.
+            required: false
+          any_http_url:
+            type: AnyHttpUrl
+            description: Any valid HTTP or HTTPS URL.
+            required: false
+          http_url:
+            type: HttpUrl
+            description: A valid HTTP or HTTPS URL.
+            required: false
+          any_websocket_url:
+            type: AnyWebsocketUrl
+            description: Any valid WebSocket or secure WebSocket URL.
+            required: false
+          websocket_url:
+            type: WebsocketUrl
+            description: A valid WebSocket or secure WebSocket URL.
+            required: false
+          file_url:
+            type: FileUrl
+            description: A valid file URL.
+            required: false
+          ftp_url:
+            type: FtpUrl
+            description: A valid FTP or FTPS URL.
+            required: false
+          postgres_dsn:
+            type: PostgresDsn
+            description: A valid PostgreSQL DSN.
+            required: false
+          cockroach_dsn:
+            type: CockroachDsn
+            description: A valid CockroachDB DSN.
+            required: false
+          amqp_dsn:
+            type: AmqpDsn
+            description: A valid AMQP DSN.
+            required: false
+          redis_dsn:
+            type: RedisDsn
+            description: A valid Redis DSN.
+            required: false
+          mongo_dsn:
+            type: MongoDsn
+            description: A valid MongoDB DSN.
+            required: false
+          kafka_dsn:
+            type: KafkaDsn
+            description: A valid Kafka DSN.
+            required: false
+          nats_dsn:
+            type: NatsDsn
+            description: A valid NATS DSN.
+            required: false
+          mysql_dsn:
+            type: MySQLDsn
+            description: A valid MySQL DSN.
+            required: false
+          mariadb_dsn:
+            type: MariaDBDsn
+            description: A valid MariaDB DSN.
+            required: false
+          clickhouse_dsn:
+            type: ClickHouseDsn
+            description: A valid ClickHouse DSN.
+            required: false
+          snowflake_dsn:
+            type: SnowflakeDsn
+            description: A valid Snowflake DSN.
+            required: false
+          email_str:
+            type: EmailStr
+            description: A valid email address.
+            required: false
+          name_email:
+            type: NameEmail
+            description: A valid name and email address.
+            required: false
+          ipvany_address:
+            type: IPvAnyAddress
+            description: A valid IPv4 or IPv6 address.
+            required: false
       

--- a/features/data/todo.yasl
+++ b/features/data/todo.yasl
@@ -1,35 +1,45 @@
-types:
-  task:
-    description: A thing to do.
-    namespace: dynamic
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
-  list_of_tasks:
-    description: A list of tasks to complete.
-    namespace: dynamic
-    properties:
-      task_list:
-        type: map[acme.taskkey, dynamic.task]
-        description: A list of tasks to do.
-        required: true
-
-enums:
-  taskkey:
-    namespace: acme
-    description: The type of shape.
-    values:
-      - task_01
-      - task_02
-      - task_03
+metadata:
+  author: John Doe
+  date: 2024-06-15
+  description: A schema for managing a to-do list with tasks.
+  license: MIT
+  version: 1.0.0
+  tags:
+    - todo
+    - tasks
+    - example
+definitions:
+  dynamic:
+    types:
+      task:
+        description: A thing to do.
+        properties:
+          description:
+            type: str
+            description: A description of the task.
+            required: true
+          owner:
+            type: str
+            description: The person responsible for the task.
+            required: false
+          complete:
+            type: bool
+            description: Is the task finished? True if yes, false if no.
+            required: true
+            default: false
+  acme:
+    types:
+      list_of_tasks:
+        description: A list of tasks to complete.
+        properties:
+          task_list:
+            type: map[acme.taskkey, dynamic.task]
+            description: A list of tasks to do.
+            required: true
+    enums:
+      taskkey:
+        description: The type of shape.
+        values:
+          - task_01
+          - task_02
+          - task_03

--- a/features/data/todo_mixed.yaml
+++ b/features/data/todo_mixed.yaml
@@ -1,0 +1,13 @@
+task_list:
+  task_01:
+    description:  Buy coffee.
+    owner: Jim
+    complete: false
+  task_02:
+    description: Lead morning standup.
+    owner: Jim
+    complete: false
+  task_03:
+    description: Refine Backlog.
+    owner: Jim
+    complete: false

--- a/features/data/todo_mixed.yasl
+++ b/features/data/todo_mixed.yasl
@@ -23,7 +23,7 @@ definitions:
         description: A list of tasks to complete.
         properties:
           task_list:
-            type: [other.taskkey, something.task]
+            type: map[other.taskkey, something.task]
             description: A list of tasks to do.
             required: true
   other:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yaml-tools"
-version = "0.2.4"
+version = "0.3.0"
 description = "A suite of tools to advance your usage of yaml.  YASL provides schema definition and verification.  YAQL let's you query your yalm as if it were a database.  YARL provides analysis and reporting.  And YATL allows you to transform yaml from one structure (schema) to another."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/schemas/gh_actions/general.yasl
+++ b/schemas/gh_actions/general.yasl
@@ -1,148 +1,143 @@
-types:
-  input:
-    namespace: github_actions
-    description: An input defined for a workflow or job that is triggered by the workflow_dispatch or workflow_call event. For more information, see "Manually running a workflow" and "Calling a workflow."
-    properties:
-      description:
-        type: str
-        description: A description of the input. The description is shown to users when they manually trigger a workflow. Default - "" (an empty string).
-        required: false
-      required:
-        type: bool
-        description: Whether the input is required. If true, the user must provide a value for the input when they manually trigger a workflow. Default - false.
-        required: false
-      default:
-        type: any
-        description: The default value for the input. If the user does not provide a value for the input when they manually trigger a workflow, this value is used. Default - "" (an empty string).
-        required: false
-        any_of:
-          - str
-          - bool
-          - int
-          - float
-      type:
-        type: input_types
-        description: The type of the input. Valid values are string, boolean, and number. Default - string.
-        required: true
-      options:
-        type: str[]
-        description: A list of possible values for the input. This property is only valid when type is choice. Default - [] (an empty list).
-        required: false
-  output:
-    namespace: github_actions
-    description: An output defined for a workflow or job that is triggered by the workflow_call event. For more information, see "Calling a workflow."
-    properties:
-      description:
-        type: str
-        description: A description of the output. The description is shown to users when they view the workflow run summary. Default - "" (an empty string).
-        required: false
-      value:
-        type: str  # TODO: consider adding regular expression validation for GitHub Actions expressions
-        description: The value of the output. This value is returned to the caller of the workflow. Default - "" (an empty string).
-        required: false
-  secrets:
-    namespace: github_actions
-    description: A secret defined for a workflow or job that is triggered by the workflow_call event. For more information, see "Calling a workflow."
-    properties:
-      description:
-        type: str
-        description: A description of the secret. The description is shown to users when they view the workflow run summary. Default - "" (an empty string).
-        required: false
-      required:
-        type: bool
-        description: Whether the secret is required. If true, the caller of the workflow must provide a value for the secret. Default - false.
-        required: false
-  permissions:
-    namespace: github_actions
-    description: The permissions granted to the GITHUB_TOKEN for the workflow or job.
-    properties:
-      actions:
-        type: permission_level
-        description: The actions permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      attestations:
-        type: permission_level
-        description: The attestations permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      checks:
-        type: permission_level
-        description: The checks permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      contents:
-        type: permission_level
-        description: The contents permission for the GITHUB_TOKEN. Can be read, write, or none. Default is read.
-        required: false
-      deployments:
-        type: permission_level
-        description: The deployments permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      id-token:
-        type: permission_level
-        description: The id-token permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      issues:
-        type: permission_level
-        description: The issues permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      models:
-        type: permission_level
-        description: The models permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      discussions:
-        type: permission_level
-        description: The discussions permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      packages:
-        type: permission_level
-        description: The packages permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      pages:
-        type: permission_level
-        description: The pages permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      pull-requests:
-        type: permission_level
-        description: The pull-requests permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      repository-projects:
-        type: permission_level
-        description: The repository-projects permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      security-events:
-        type: permission_level
-        description: The security-events permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
-      statuses:
-        type: permission_level
-        description: The statuses permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
-        required: false
+definitions:
+  github_actions:
+    types:
+      input:
+        description: An input defined for a workflow or job that is triggered by the workflow_dispatch or workflow_call event. For more information, see "Manually running a workflow" and "Calling a workflow."
+        properties:
+          description:
+            type: str
+            description: A description of the input. The description is shown to users when they manually trigger a workflow. Default - "" (an empty string).
+            required: false
+          required:
+            type: bool
+            description: Whether the input is required. If true, the user must provide a value for the input when they manually trigger a workflow. Default - false.
+            required: false
+          default:
+            type: any
+            description: The default value for the input. If the user does not provide a value for the input when they manually trigger a workflow, this value is used. Default - "" (an empty string).
+            required: false
+            any_of:
+              - str
+              - bool
+              - int
+              - float
+          type:
+            type: input_types
+            description: The type of the input. Valid values are string, boolean, and number. Default - string.
+            required: true
+          options:
+            type: str[]
+            description: A list of possible values for the input. This property is only valid when type is choice. Default - [] (an empty list).
+            required: false
+      output:
+        description: An output defined for a workflow or job that is triggered by the workflow_call event. For more information, see "Calling a workflow."
+        properties:
+          description:
+            type: str
+            description: A description of the output. The description is shown to users when they view the workflow run summary. Default - "" (an empty string).
+            required: false
+          value:
+            type: str  # TODO: consider adding regular expression validation for GitHub Actions expressions
+            description: The value of the output. This value is returned to the caller of the workflow. Default - "" (an empty string).
+            required: false
+      secrets:
+        description: A secret defined for a workflow or job that is triggered by the workflow_call event. For more information, see "Calling a workflow."
+        properties:
+          description:
+            type: str
+            description: A description of the secret. The description is shown to users when they view the workflow run summary. Default - "" (an empty string).
+            required: false
+          required:
+            type: bool
+            description: Whether the secret is required. If true, the caller of the workflow must provide a value for the secret. Default - false.
+            required: false
+      permissions:
+        description: The permissions granted to the GITHUB_TOKEN for the workflow or job.
+        properties:
+          actions:
+            type: permission_level
+            description: The actions permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          attestations:
+            type: permission_level
+            description: The attestations permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          checks:
+            type: permission_level
+            description: The checks permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          contents:
+            type: permission_level
+            description: The contents permission for the GITHUB_TOKEN. Can be read, write, or none. Default is read.
+            required: false
+          deployments:
+            type: permission_level
+            description: The deployments permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          id-token:
+            type: permission_level
+            description: The id-token permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          issues:
+            type: permission_level
+            description: The issues permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          models:
+            type: permission_level
+            description: The models permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          discussions:
+            type: permission_level
+            description: The discussions permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          packages:
+            type: permission_level
+            description: The packages permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          pages:
+            type: permission_level
+            description: The pages permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          pull-requests:
+            type: permission_level
+            description: The pull-requests permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          repository-projects:
+            type: permission_level
+            description: The repository-projects permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          security-events:
+            type: permission_level
+            description: The security-events permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
+          statuses:
+            type: permission_level
+            description: The statuses permission for the GITHUB_TOKEN. Can be read, write, or none. Default is none.
+            required: false
 
-  concurrency:
-    namespace: github_actions
-    description: A concurrency group ensures that only a single job or workflow using the same concurrency group will run at a time. For more information, see "Using concurrency to control access to resources."
-    properties:
-      group:
-        type: str  # TODO: consider adding regular expression validation for GitHub Actions expressions
-        description: A string or expression that defines a concurrency group. You can use the github.workflow and github.ref context to create a unique group for each workflow and branch. For more information, see "Using concurrency to control access to resources."
-        required: true
-      cancel-in-progress:
-        type: bool
-        description: If true, any currently running job or workflow in the same concurrency group will be cancelled when a new job or workflow is triggered. Default is false.
-        required: false
-enums:
-  permission_level:
-    namespace: github_actions
-    description:  GitHub permission levels for the workflow or job.
-    values:
-      - read
-      - write
-      - none
-  input_types:
-    namespace: github_actions
-    description:  GitHub input types for workflow_dispatch and workflow_call events.
-    values:
-      - string
-      - boolean
-      - number
-      - choice
-      - environment
+      concurrency:
+        description: A concurrency group ensures that only a single job or workflow using the same concurrency group will run at a time. For more information, see "Using concurrency to control access to resources."
+        properties:
+          group:
+            type: str  # TODO: consider adding regular expression validation for GitHub Actions expressions
+            description: A string or expression that defines a concurrency group. You can use the github.workflow and github.ref context to create a unique group for each workflow and branch. For more information, see "Using concurrency to control access to resources."
+            required: true
+          cancel-in-progress:
+            type: bool
+            description: If true, any currently running job or workflow in the same concurrency group will be cancelled when a new job or workflow is triggered. Default is false.
+            required: false
+    enums:
+      permission_level:
+        description:  GitHub permission levels for the workflow or job.
+        values:
+          - read
+          - write
+          - none
+      input_types:
+        description:  GitHub input types for workflow_dispatch and workflow_call events.
+        values:
+          - string
+          - boolean
+          - number
+          - choice
+          - environment

--- a/schemas/gh_actions/github_actions.yasl
+++ b/schemas/gh_actions/github_actions.yasl
@@ -1,289 +1,281 @@
 imports:
   - ./on.yasl
-types:
-  step:
-    namespace: github_actions
-    description: A step in a job. A step can run commands or use an action.
-    properties:
-      id:
-        type: str
-        description: A unique identifier for the step. This identifier can be used to reference the step in other parts of the workflow, such as in the needs context. Default is a generated UUID.
-        required: false
-      if:
-        type: str
-        description: A conditional expression that determines whether the step will run. For more information, see "Context and expression syntax for GitHub Actions."
-        required: false
-      name:
-        type: str
-        description: The name of the step.
-        required: false
-      uses:
-        type: str
-        description: The action to run. This can be a Docker container, a JavaScript action, or a composite action. For more information, see "Finding and customizing actions."
-        required: false
-      run:
-        type: str
-        description: The command to run. This can be a shell command or a script. For more information, see "Workflow syntax for GitHub Actions."
-        required: false
-      working-directory:
-        type: str
-        description: The working directory for the step. This is the directory where the command specified in the run property is executed. For more information, see "Workflow syntax for GitHub Actions."
-        required: false
-      shell:
-        type: str
-        description: The shell to use for the step. This can be bash, sh, pwsh, python, or any other shell available on the runner. For more information, see "Workflow syntax for GitHub Actions."
-        required: false
-      with: # TODO:  consider the special case of with.entrypoint / with.args, but this should work for now
-        type: map[str, any]
-        description: A map of input names to input values. These inputs are passed to the action specified in the uses property. For more information, see "Input parameters for actions."
-        required: false
-      env:
-        type: map[str, str]
-        description: A map of environment variable names to environment variable values. These environment variables are available to the step and any actions that the step runs. For more information, see "Environment variables in GitHub Actions."
-        required: false
-      continue-on-error:
-        type: bool
-        description: If true, the step will continue to run even if it fails. Default is false. For more information, see "Workflow syntax for GitHub Actions."
-        required: false
-      timeout-minutes:
-        type: int
-        description: The maximum time that the step is allowed to run, in minutes. If the step runs longer than this time, it is automatically cancelled. Default is 360 minutes (6 hours). For more information, see "Workflow syntax for GitHub Actions."
-        required: false
-  job_defaults_run:
-    namespace: github_actions
-    description: Default settings for the run step. For more information, see "Default settings for workflows."
-    properties:
-      shell:
-        type: str
-        description: The shell to use for the run step. For more information, see "About shells for GitHub Actions."
-        required: false
-      working-directory:
-        type: str
-        description: The working directory for the run step. For more information, see "Workflow syntax for GitHub Actions."
-        required: false
-  job_defaults:
-    namespace: github_actions
-    description: Default settings that are applied to all steps in the job. You can also define default settings for individual steps. For more information, see "Default settings for workflows."
-    properties:
-      run:
-        type: job_defaults_run
-        description: Default settings for the run step. For more information, see "Default settings for workflows."
-        required: false
-  job_environment:
-    namespace: github_actions
-    description: A job environment is a set of environment variables that are available to all steps in the job. You can also define environment variables for individual steps. For more information, see "Environment variables."
-    properties:
-      name:
-        type: str
-        description: The name of the environment. The name is used to identify the environment in the workflow run summary and in the GitHub Actions API.
-        required: true
-      url:
-        type: str
-        description: The URL of the environment. The URL is shown to users when they view the workflow run summary.
-        required: false
-  strategy:
-    namespace: github_actions
-    description: A strategy for a job that defines a matrix of different configurations to run the job with. For more information, see "Using a matrix for your jobs."
-    properties:
-      matrix:
-        type: map[str, any]
-        description: A map of matrix configuration options. For more information, see "Using a matrix for your jobs."
-        required: false
-      fail-fast:
-        type: map[str, any]  # TODO: consider making this more specific
-        description: If true, the job will stop running all other configurations in the matrix if one configuration fails. Default is true. For more information, see "Using a matrix for your jobs."
-        required: false
-      max-parallel:
-        type: int
-        description: The maximum number of configurations in the matrix that can run at the same time. Default is no limit. For more information, see "Using a matrix for your jobs."
-        required: false
-  container_credentials:
-    namespace: github_actions
-    description: The credentials to use to access a private container image. For more information, see "Using a container for a job."
-    properties:
-      username:
-        type: str
-        description: The username to use to access the container image. For more information, see "Using a container for a job."
-        required: true
-      password:
-        type: str
-        description: The password to use to access the container image. For more information, see "Using a container for a job."
-        required: true
-  container:
-    namespace: github_actions
-    description: A container to run the job in. For more information, see "Using a container for a job."
-    properties:
-      image:
-        type: str
-        description: The image to use for the container. You can use a Docker Hub image or a GitHub Container Registry image. For more information, see "Using a container for a job."
-        required: true
-      credentials:
-        type: container_credentials
-        description: The credentials to use to access a private container image. For more information, see "Using a container for a job."
-        required: false
-      ports:
-        type: str[]
-        description: A list of ports to expose from the container. For more information, see "Using a container for a job."
-        required: false
-      env:
-        type: map[str, str]
-        description: A map of environment variables to set in the container. For more information, see "Using a container for a job."
-        required: false
-      volumes:
-        type: str[]
-        description: A list of volumes to mount in the container. For more information, see "Using a container for a job."
-        required: false
-      options:
-        type: str
-        description: Additional options to pass to the docker run command when starting the container. For more information, see "Using a container for a job."
-        required: false
-  job:
-    namespace: github_actions
-    description: A job is a set of steps in a workflow that execute on the same runner. By default, jobs run in parallel. You can use the needs keyword to configure a job to run after another job. For more information, see "About jobs."
-    properties:
-      name:
-        type: str
-        description: The name of the job. The name is used to identify the job in the workflow run summary and in the GitHub Actions API. Default is the job_id.
-        required: false
-      permissions:
-        type: permissions
-        description: The permissions granted to the GITHUB_TOKEN for the job. You can specify permissions for the entire workflow or for individual jobs. For more information, see "Permissions for the GITHUB_TOKEN."
-        required: false
-      needs:
-        type: any
-        description: The jobs that must complete successfully before this job will run. You can specify a single job or an array of jobs. For more information, see "About jobs."
-        required: false
-        any_of:
-          - str
-          - str[]
-      if:
-        type: str  # TODO: consider adding regular expression validation for GitHub Actions expressions
-        description: A conditional expression that determines whether the job will run. For more information, see "Context and expression syntax for GitHub Actions."
-        required: false
-      runs-on:
-        type: any
-        description: The type of runner that the job will run on. You can specify a single runner type or an array of runner types. For more information, see "About self-hosted runners."
-        required: true
-        any_of:
-          - str
-          - str[]
-      environment:
-        type: job_environment
-        description: A job environment is a set of environment variables that are available to all steps in the job. You can also define environment variables for individual steps. For more information, see "Environment variables."
-        required: false
-      concurrency:
-        type: concurrency
-        description: A concurrency group ensures that only a single job or workflow using the same concurrency group will run at a time. For more information, see "Using concurrency to control access to resources."
-        required: false
-      outputs:
-        type: map[str, str]  # TODO: consider making this more specific
-        description: A map of output names to output properties. For more information, see "Defining job outputs."
-        required: false
-      env:
-        type: map[str, str]
-        description: A map of environment variables that are available to all steps in the job. You can also define environment variables for individual steps. For more information, see "Environment variables."
-        required: false
-      defaults:
-        type: job_defaults
-        description: Default settings that are applied to all steps in the job. You can also define default settings for individual steps. For more information, see "Default settings for workflows."
-        required: false
-      steps:
-        type: step[]
-        description: A map of step IDs to step properties. A step is an individual task that a job performs. For more information, see "About steps."
-        required: true
-      timeout-minutes:
-        type: int
-        description: The maximum number of minutes a job can run before it is automatically cancelled. Default is 360 minutes (6 hours). For more information, see "Workflow syntax for GitHub Actions."
-        required: false
-      strategy:
-        type: strategy
-        description: A strategy for a job that defines a matrix of different configurations to run the job with. For more information, see "Using a matrix for your jobs."
-        required: false
-      continue-on-error:
-        type: bool
-        description: If true, the job will continue to run even if a step fails. Default is false. For more information, see "Workflow syntax for GitHub Actions."
-        required: false
-      container:
-        type: container
-        description: The container to run the job in. For more information, see "Using a container for a job."
-        required: false
-      services:
-        type: map[str, container]  # TODO: consider making this more specific
-        description: A map of service names to service properties. A service is a Docker container that is linked to the job's container and can be used to provide additional functionality, such as a database or cache. For more information, see "About services."
-        required: false
-      uses:
-        type: str
-        description: |
-          The location and version of a reusable workflow file to run as a job. Use one of the following syntaxes:
-
-            {owner}/{repo}/.github/workflows/{filename}@{ref} for reusable workflows in public and private repositories.
-            ./.github/workflows/{filename} for reusable workflows in the same repository.
-        required: false
-      with:
-        type: map[str, any]  # TODO: consider making this more specific
-        description: A map of input names to input values. For more information, see "Calling a workflow."
-        required: false
-      secrets:
-        type: any
-        description: A map of secret names to secret values. For more information, see "Calling a workflow."
-        required: false
-        any_of:
-          - secrets_inherit
-          - map[str, str]
+definitions:
   github_actions:
-    namespace: github_actions
-    description:  The root time for a GitHub Actions workflow file.
-    properties:
-      name:
-        type: str
-        description: |
-          The name of the workflow. GitHub displays the names of your workflows under your repository's "Actions" tab. If you omit name, GitHub displays the workflow file path relative to the root of the repository.
-        required: false
-      run-name:
-        type: str
-        description: |
-          SThe name for workflow runs generated from the workflow. GitHub displays the workflow run name in the list of workflow runs on your repository's "Actions" tab. If run-name is omitted or is only whitespace, then the run name is set to event-specific information for the workflow run. For example, for a workflow triggered by a push or pull_request event, it is set as the commit message or the title of the pull request.
+    types:
+      step:
+        description: A step in a job. A step can run commands or use an action.
+        properties:
+          id:
+            type: str
+            description: A unique identifier for the step. This identifier can be used to reference the step in other parts of the workflow, such as in the needs context. Default is a generated UUID.
+            required: false
+          if:
+            type: str
+            description: A conditional expression that determines whether the step will run. For more information, see "Context and expression syntax for GitHub Actions."
+            required: false
+          name:
+            type: str
+            description: The name of the step.
+            required: false
+          uses:
+            type: str
+            description: The action to run. This can be a Docker container, a JavaScript action, or a composite action. For more information, see "Finding and customizing actions."
+            required: false
+          run:
+            type: str
+            description: The command to run. This can be a shell command or a script. For more information, see "Workflow syntax for GitHub Actions."
+            required: false
+          working-directory:
+            type: str
+            description: The working directory for the step. This is the directory where the command specified in the run property is executed. For more information, see "Workflow syntax for GitHub Actions."
+            required: false
+          shell:
+            type: str
+            description: The shell to use for the step. This can be bash, sh, pwsh, python, or any other shell available on the runner. For more information, see "Workflow syntax for GitHub Actions."
+            required: false
+          with: # TODO:  consider the special case of with.entrypoint / with.args, but this should work for now
+            type: map[str, any]
+            description: A map of input names to input values. These inputs are passed to the action specified in the uses property. For more information, see "Input parameters for actions."
+            required: false
+          env:
+            type: map[str, str]
+            description: A map of environment variable names to environment variable values. These environment variables are available to the step and any actions that the step runs. For more information, see "Environment variables in GitHub Actions."
+            required: false
+          continue-on-error:
+            type: bool
+            description: If true, the step will continue to run even if it fails. Default is false. For more information, see "Workflow syntax for GitHub Actions."
+            required: false
+          timeout-minutes:
+            type: int
+            description: The maximum time that the step is allowed to run, in minutes. If the step runs longer than this time, it is automatically cancelled. Default is 360 minutes (6 hours). For more information, see "Workflow syntax for GitHub Actions."
+            required: false
+      job_defaults_run:
+        description: Default settings for the run step. For more information, see "Default settings for workflows."
+        properties:
+          shell:
+            type: str
+            description: The shell to use for the run step. For more information, see "About shells for GitHub Actions."
+            required: false
+          working-directory:
+            type: str
+            description: The working directory for the run step. For more information, see "Workflow syntax for GitHub Actions."
+            required: false
+      job_defaults:
+        description: Default settings that are applied to all steps in the job. You can also define default settings for individual steps. For more information, see "Default settings for workflows."
+        properties:
+          run:
+            type: job_defaults_run
+            description: Default settings for the run step. For more information, see "Default settings for workflows."
+            required: false
+      job_environment:
+        description: A job environment is a set of environment variables that are available to all steps in the job. You can also define environment variables for individual steps. For more information, see "Environment variables."
+        properties:
+          name:
+            type: str
+            description: The name of the environment. The name is used to identify the environment in the workflow run summary and in the GitHub Actions API.
+            required: true
+          url:
+            type: str
+            description: The URL of the environment. The URL is shown to users when they view the workflow run summary.
+            required: false
+      strategy:
+        description: A strategy for a job that defines a matrix of different configurations to run the job with. For more information, see "Using a matrix for your jobs."
+        properties:
+          matrix:
+            type: map[str, any]
+            description: A map of matrix configuration options. For more information, see "Using a matrix for your jobs."
+            required: false
+          fail-fast:
+            type: map[str, any]  # TODO: consider making this more specific
+            description: If true, the job will stop running all other configurations in the matrix if one configuration fails. Default is true. For more information, see "Using a matrix for your jobs."
+            required: false
+          max-parallel:
+            type: int
+            description: The maximum number of configurations in the matrix that can run at the same time. Default is no limit. For more information, see "Using a matrix for your jobs."
+            required: false
+      container_credentials:
+        description: The credentials to use to access a private container image. For more information, see "Using a container for a job."
+        properties:
+          username:
+            type: str
+            description: The username to use to access the container image. For more information, see "Using a container for a job."
+            required: true
+          password:
+            type: str
+            description: The password to use to access the container image. For more information, see "Using a container for a job."
+            required: true
+      container:
+        description: A container to run the job in. For more information, see "Using a container for a job."
+        properties:
+          image:
+            type: str
+            description: The image to use for the container. You can use a Docker Hub image or a GitHub Container Registry image. For more information, see "Using a container for a job."
+            required: true
+          credentials:
+            type: container_credentials
+            description: The credentials to use to access a private container image. For more information, see "Using a container for a job."
+            required: false
+          ports:
+            type: str[]
+            description: A list of ports to expose from the container. For more information, see "Using a container for a job."
+            required: false
+          env:
+            type: map[str, str]
+            description: A map of environment variables to set in the container. For more information, see "Using a container for a job."
+            required: false
+          volumes:
+            type: str[]
+            description: A list of volumes to mount in the container. For more information, see "Using a container for a job."
+            required: false
+          options:
+            type: str
+            description: Additional options to pass to the docker run command when starting the container. For more information, see "Using a container for a job."
+            required: false
+      job:
+        description: A job is a set of steps in a workflow that execute on the same runner. By default, jobs run in parallel. You can use the needs keyword to configure a job to run after another job. For more information, see "About jobs."
+        properties:
+          name:
+            type: str
+            description: The name of the job. The name is used to identify the job in the workflow run summary and in the GitHub Actions API. Default is the job_id.
+            required: false
+          permissions:
+            type: permissions
+            description: The permissions granted to the GITHUB_TOKEN for the job. You can specify permissions for the entire workflow or for individual jobs. For more information, see "Permissions for the GITHUB_TOKEN."
+            required: false
+          needs:
+            type: any
+            description: The jobs that must complete successfully before this job will run. You can specify a single job or an array of jobs. For more information, see "About jobs."
+            required: false
+            any_of:
+              - str
+              - str[]
+          if:
+            type: str  # TODO: consider adding regular expression validation for GitHub Actions expressions
+            description: A conditional expression that determines whether the job will run. For more information, see "Context and expression syntax for GitHub Actions."
+            required: false
+          runs-on:
+            type: any
+            description: The type of runner that the job will run on. You can specify a single runner type or an array of runner types. For more information, see "About self-hosted runners."
+            required: true
+            any_of:
+              - str
+              - str[]
+          environment:
+            type: job_environment
+            description: A job environment is a set of environment variables that are available to all steps in the job. You can also define environment variables for individual steps. For more information, see "Environment variables."
+            required: false
+          concurrency:
+            type: concurrency
+            description: A concurrency group ensures that only a single job or workflow using the same concurrency group will run at a time. For more information, see "Using concurrency to control access to resources."
+            required: false
+          outputs:
+            type: map[str, str]  # TODO: consider making this more specific
+            description: A map of output names to output properties. For more information, see "Defining job outputs."
+            required: false
+          env:
+            type: map[str, str]
+            description: A map of environment variables that are available to all steps in the job. You can also define environment variables for individual steps. For more information, see "Environment variables."
+            required: false
+          defaults:
+            type: job_defaults
+            description: Default settings that are applied to all steps in the job. You can also define default settings for individual steps. For more information, see "Default settings for workflows."
+            required: false
+          steps:
+            type: step[]
+            description: A map of step IDs to step properties. A step is an individual task that a job performs. For more information, see "About steps."
+            required: true
+          timeout-minutes:
+            type: int
+            description: The maximum number of minutes a job can run before it is automatically cancelled. Default is 360 minutes (6 hours). For more information, see "Workflow syntax for GitHub Actions."
+            required: false
+          strategy:
+            type: strategy
+            description: A strategy for a job that defines a matrix of different configurations to run the job with. For more information, see "Using a matrix for your jobs."
+            required: false
+          continue-on-error:
+            type: bool
+            description: If true, the job will continue to run even if a step fails. Default is false. For more information, see "Workflow syntax for GitHub Actions."
+            required: false
+          container:
+            type: container
+            description: The container to run the job in. For more information, see "Using a container for a job."
+            required: false
+          services:
+            type: map[str, container]  # TODO: consider making this more specific
+            description: A map of service names to service properties. A service is a Docker container that is linked to the job's container and can be used to provide additional functionality, such as a database or cache. For more information, see "About services."
+            required: false
+          uses:
+            type: str
+            description: |
+              The location and version of a reusable workflow file to run as a job. Use one of the following syntaxes:
 
-          This value can include expressions and can reference the github and inputs contexts.
+                {owner}/{repo}/.github/workflows/{filename}@{ref} for reusable workflows in public and private repositories.
+                ./.github/workflows/{filename} for reusable workflows in the same repository.
+            required: false
+          with:
+            type: map[str, any]  # TODO: consider making this more specific
+            description: A map of input names to input values. For more information, see "Calling a workflow."
+            required: false
+          secrets:
+            type: any
+            description: A map of secret names to secret values. For more information, see "Calling a workflow."
+            required: false
+            any_of:
+              - secrets_inherit
+              - map[str, str]
+      github_actions:
+        description:  The root time for a GitHub Actions workflow file.
+        properties:
+          name:
+            type: str
+            description: |
+              The name of the workflow. GitHub displays the names of your workflows under your repository's "Actions" tab. If you omit name, GitHub displays the workflow file path relative to the root of the repository.
+            required: false
+          run-name:
+            type: str
+            description: |
+              SThe name for workflow runs generated from the workflow. GitHub displays the workflow run name in the list of workflow runs on your repository's "Actions" tab. If run-name is omitted or is only whitespace, then the run name is set to event-specific information for the workflow run. For example, for a workflow triggered by a push or pull_request event, it is set as the commit message or the title of the pull request.
 
-          Example of run-name
-          run-name: Deploy to ${{ inputs.deploy_target }} by @${{ github.actor }}
-        required: false
-      permissions:
-        type: permissions
-        description: |
-          The permissions granted to the GITHUB_TOKEN for the workflow or job. You can specify permissions for the entire workflow or for individual jobs. For more information, see "Permissions for the GITHUB_TOKEN."
-        required: false
-      on:
-        type: on_workflow
-        description: |
-          The name of the event that triggers the workflow. You can configure a workflow to run when a specific activity occurs in your repository, or you can schedule workflows to run at specific times. You can also configure a workflow to run manually.
+              This value can include expressions and can reference the github and inputs contexts.
 
-          You can specify multiple events for a single workflow. For more information about the available events, see "Events that trigger workflows."
-        required: false
-      env:
-        type: map[str, str]
-        description: |
-          A map of environment variables that are available to all jobs and steps in the workflow. You can also define environment variables for individual jobs and steps. For more information, see "Environment variables."
-        required: false
-      defaults:
-        type: map[str, any]  # TODO: consider making this more specific
-        description: |
-          Default settings that are applied to all jobs and steps in the workflow. You can also define default settings for individual jobs and steps. For more information, see "Default settings for workflows."
-        required: false
-      concurrency:
-        type: concurrency
-        description: |
-          A concurrency group ensures that only a single job or workflow using the same concurrency group will run at a time. For more information, see "Using concurrency to control access to resources."
-        required: false
-      jobs:
-        type: map[str, job]
-        description: |
-          A map of job IDs to job properties. A job is a set of steps in a workflow that execute on the same runner. By default, jobs run in parallel. You can use the needs keyword to configure a job to run after another job. For more information, see "About jobs."
-        required: true
-enums:
-  secrets_inherit:
-    namespace: github_actions
-    description:  Whether to inherit secrets from the parent workflow when using a reusable workflow. Can be true or false. Default is false.
-    values:
-      - inherit
+              Example of run-name
+              run-name: Deploy to ${{ inputs.deploy_target }} by @${{ github.actor }}
+            required: false
+          permissions:
+            type: permissions
+            description: |
+              The permissions granted to the GITHUB_TOKEN for the workflow or job. You can specify permissions for the entire workflow or for individual jobs. For more information, see "Permissions for the GITHUB_TOKEN."
+            required: false
+          on:
+            type: on_workflow
+            description: |
+              The name of the event that triggers the workflow. You can configure a workflow to run when a specific activity occurs in your repository, or you can schedule workflows to run at specific times. You can also configure a workflow to run manually.
+
+              You can specify multiple events for a single workflow. For more information about the available events, see "Events that trigger workflows."
+            required: false
+          env:
+            type: map[str, str]
+            description: |
+              A map of environment variables that are available to all jobs and steps in the workflow. You can also define environment variables for individual jobs and steps. For more information, see "Environment variables."
+            required: false
+          defaults:
+            type: map[str, any]  # TODO: consider making this more specific
+            description: |
+              Default settings that are applied to all jobs and steps in the workflow. You can also define default settings for individual jobs and steps. For more information, see "Default settings for workflows."
+            required: false
+          concurrency:
+            type: concurrency
+            description: |
+              A concurrency group ensures that only a single job or workflow using the same concurrency group will run at a time. For more information, see "Using concurrency to control access to resources."
+            required: false
+          jobs:
+            type: map[str, job]
+            description: |
+              A map of job IDs to job properties. A job is a set of steps in a workflow that execute on the same runner. By default, jobs run in parallel. You can use the needs keyword to configure a job to run after another job. For more information, see "About jobs."
+            required: true
+    enums:
+      secrets_inherit:
+        description:  Whether to inherit secrets from the parent workflow when using a reusable workflow. Can be true or false. Default is false.
+        values:
+          - inherit

--- a/schemas/gh_actions/on.yasl
+++ b/schemas/gh_actions/on.yasl
@@ -1,303 +1,295 @@
 imports:
   - ./general.yasl
-types:
-  on_pull_request_event:
-    namespace: github_actions
-    description: A pull request event that triggers the workflow.
-    properties:
-      types:
-        type: on_event_type[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      branches:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      branches-ignore:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      paths:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      paths-ignore:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-  on_event_types:
-    namespace: github_actions
-    description: A GitHub event type that triggers the workflow.
-    properties:
-      types:
-        type: on_event_type[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-  on_pull_request_target_event:
-    namespace: github_actions
-    description: A pull request event that triggers the workflow.
-    properties:
-      types:
-        type: on_event_type[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      branches:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      branches-ignore:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      paths:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      paths-ignore:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-  on_push_event:
-    namespace: github_actions
-    description: A push event that triggers the workflow.
-    properties:
-      types:
-        type: on_event_type[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      branches:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      branches-ignore:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      tags:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      tags-ignore:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      paths:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      paths-ignore:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-  on_workflow_call_event:
-    namespace: github_actions
-    description: A workflow call event that triggers the workflow.
-    properties:
-      types:
-        type: on_event_type[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      inputs:
-        type: map[str, input]
-        description: A map of input names to input properties. For more information, see "Calling a workflow."
-        required: false
-      outputs:
-        type: map[str, output]
-        description: A map of output names to output properties. For more information, see "Calling a workflow."
-        required: false
-      secrets:
-        type: map[str, secrets]
-        description: A map of secret names to secret properties. For more information, see "Calling a workflow."
-        required: false
-  on_workflow_run_event:
-    namespace: github_actions
-    description: A workflow run request event that triggers the workflow.
-    properties:
-      types:
-        type: on_event_type[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      branches:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      branches-ignore:
-        type: str[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-  on_workflow_dispatch_event:
-    namespace: github_actions
-    description: A workflow call event that triggers the workflow.
-    properties:
-      types:
-        type: on_event_type[]
-        description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
-        required: false
-      inputs:
-        type: map[str, input]
-        description: A map of input names to input properties. For more information, see "Calling a workflow."
-        required: false
-  cron:
-    namespace: github_actions
-    description: A single defined cron schedule entry. For more information, see "Creating a scheduled workflow."
-    properties:
-      cron:
-        type: str
-        description: A cron syntax string. For more information, see "Creating a scheduled workflow."
-        required: true
-        str_regex: ^([\d\*,\/\-]+)\s+([\d\*,\/\-]+)\s+([\d\*,\/\-]+)\s+([\d\*,\/\-]+)\s+([\d\*,\/\-]+)$
-  on_workflow:
-    namespace: github_actions
-    description:  The name of the event that triggers the workflow. You can configure a workflow to run when a specific activity occurs in your repository, or you can schedule workflows to run at specific times. You can also configure a workflow to run manually.
-
-      You can specify multiple events for a single workflow. For more information about the available events, see "Events that trigger workflows."
-    properties:
-      label:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      branch_protection_rule:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      check_run:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      check_suite:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      create:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      delete:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      deployment:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      deployment_status:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      discussion:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      discussion_comment:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      fork:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      gollum:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      issue_comment:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      issues:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      merge_group:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      milestone:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      page_build:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      project:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      project_card:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      project_column:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      public:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      pull_request:
-        type: on_pull_request_event
+definitions:
+  github_actions:
+    types:
+      on_pull_request_event:
         description: A pull request event that triggers the workflow.
-        required: false
-      pull_request_review:
-        type: on_event_type
+        properties:
+          types:
+            type: on_event_type[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          branches:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          branches-ignore:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          paths:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          paths-ignore:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+      on_event_types:
         description: A GitHub event type that triggers the workflow.
-        required: false
-      pull_request_review_comment:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      pull_request_target:
-        type: on_pull_request_target_event
+        properties:
+          types:
+            type: on_event_type[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+      on_pull_request_target_event:
         description: A pull request event that triggers the workflow.
-        required: false
-      push:
-        type: on_push_event
+        properties:
+          types:
+            type: on_event_type[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          branches:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          branches-ignore:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          paths:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          paths-ignore:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+      on_push_event:
         description: A push event that triggers the workflow.
-        required: false
-      registry_package:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      release:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      repository_dispatch:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      schedule:
-        type: cron[]
-        description: A scheduled event that triggers the workflow.
-        required: false
-      status:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      watch:
-        type: on_event_type
-        description: A GitHub event type that triggers the workflow.
-        required: false
-      workflow_call:
-        type: on_workflow_call_event
+        properties:
+          types:
+            type: on_event_type[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          branches:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          branches-ignore:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          tags:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          tags-ignore:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          paths:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          paths-ignore:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+      on_workflow_call_event:
         description: A workflow call event that triggers the workflow.
-        required: false
-      workflow_dispatch:
-        type: on_workflow_dispatch_event
-        description: A workflow call event that triggers the workflow.
-        required: false
-      workflow_run:
-        type: on_workflow_run_event
+        properties:
+          types:
+            type: on_event_type[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          inputs:
+            type: map[str, input]
+            description: A map of input names to input properties. For more information, see "Calling a workflow."
+            required: false
+          outputs:
+            type: map[str, output]
+            description: A map of output names to output properties. For more information, see "Calling a workflow."
+            required: false
+          secrets:
+            type: map[str, secrets]
+            description: A map of secret names to secret properties. For more information, see "Calling a workflow."
+            required: false
+      on_workflow_run_event:
         description: A workflow run request event that triggers the workflow.
-        required: false
-  
-enums:
-  on_event_type:
-    namespace: github_actions
-    description:  GitHub event types for issues and pull requests.
-    values:
-      - created
-      - edited
-  
+        properties:
+          types:
+            type: on_event_type[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          branches:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          branches-ignore:
+            type: str[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+      on_workflow_dispatch_event:
+        description: A workflow call event that triggers the workflow.
+        properties:
+          types:
+            type: on_event_type[]
+            description: See filter descriptions in github actions documentation (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax).
+            required: false
+          inputs:
+            type: map[str, input]
+            description: A map of input names to input properties. For more information, see "Calling a workflow."
+            required: false
+      cron:
+        description: A single defined cron schedule entry. For more information, see "Creating a scheduled workflow."
+        properties:
+          cron:
+            type: str
+            description: A cron syntax string. For more information, see "Creating a scheduled workflow."
+            required: true
+            str_regex: ^([\d\*,\/\-]+)\s+([\d\*,\/\-]+)\s+([\d\*,\/\-]+)\s+([\d\*,\/\-]+)\s+([\d\*,\/\-]+)$
+      on_workflow:
+        description:  The name of the event that triggers the workflow. You can configure a workflow to run when a specific activity occurs in your repository, or you can schedule workflows to run at specific times. You can also configure a workflow to run manually.
+
+          You can specify multiple events for a single workflow. For more information about the available events, see "Events that trigger workflows."
+        properties:
+          label:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          branch_protection_rule:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          check_run:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          check_suite:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          create:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          delete:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          deployment:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          deployment_status:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          discussion:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          discussion_comment:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          fork:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          gollum:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          issue_comment:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          issues:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          merge_group:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          milestone:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          page_build:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          project:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          project_card:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          project_column:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          public:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          pull_request:
+            type: on_pull_request_event
+            description: A pull request event that triggers the workflow.
+            required: false
+          pull_request_review:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          pull_request_review_comment:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          pull_request_target:
+            type: on_pull_request_target_event
+            description: A pull request event that triggers the workflow.
+            required: false
+          push:
+            type: on_push_event
+            description: A push event that triggers the workflow.
+            required: false
+          registry_package:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          release:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          repository_dispatch:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          schedule:
+            type: cron[]
+            description: A scheduled event that triggers the workflow.
+            required: false
+          status:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          watch:
+            type: on_event_type
+            description: A GitHub event type that triggers the workflow.
+            required: false
+          workflow_call:
+            type: on_workflow_call_event
+            description: A workflow call event that triggers the workflow.
+            required: false
+          workflow_dispatch:
+            type: on_workflow_dispatch_event
+            description: A workflow call event that triggers the workflow.
+            required: false
+          workflow_run:
+            type: on_workflow_run_event
+            description: A workflow run request event that triggers the workflow.
+            required: false
+      
+    enums:
+      on_event_type:
+        description:  GitHub event types for issues and pull requests.
+        values:
+          - created
+          - edited
+      

--- a/src/yasl/README.md
+++ b/src/yasl/README.md
@@ -26,9 +26,9 @@ usage: yasl [-h] [--version] [--quiet] [--verbose] [--output {text,json,yaml}] [
 YASL - YAML Advanced Schema Language CLI Tool
 
 positional arguments:
-  schema                YASL schema file
-  yaml                  YAML data file
-  model_name            YASL schema name for the yaml data file (optional)
+  schema                YASL schema file or directory
+  yaml                  YAML data file or directory
+  model_name            YASL schema type name for the yaml data file (optional)
 
 options:
   -h, --help            show this help message and exit
@@ -39,8 +39,6 @@ options:
                         Set output format (text, json, yaml). Default is text.
 ```
 
-Note that all options must be provided before the file arguments.
-
 ## Defining YASL Schemas
 
 At the heart of YASL is the schema definition.
@@ -48,11 +46,227 @@ The intent is to make schema definition as simple and familiar as possible by us
 There are a few key concepts to consider when defining your YASL schema: primitives, enumerations, and data types.
 Once you've mastered these, you'll want to consider things like data validation, referential integrity, and version control.
 
+The root of a YASL schema allows you to define:
+
+```yaml
+imports:
+  ...  # List of other yasl schemas to integrate.
+metadata:
+  ...  # Key-value pairs for your relevant information.
+definitions:
+  ...  # Namespaces with type and enumeration definitions.
+```
+
+All of these are optional to give you maximum flexibility.
+Perhaps you have a top level YASL schema that only provides metadata and imports all definitions from other files.
+Or perhaps you put all your data definitions into a single file and don't care about metadata.
+The YASL schema does not constrain your content organization decision process.
+
 ### Comments
 
 YASL is just YAML, so comments work the same way.
 Start your comment with a `#` and everything after that is comment text.
 You can do full or partial line comments.
+
+### Imports
+
+YASL schemas allow you to organize your data definitions across a collection of files.
+It is recommended that you be as explicit as possible by maintaining a single 'entry point' for your data definitions.
+
+Let's assume you have an engineering team working various products and features and a sales team delivering the resulting products and features to customers.
+
+Your schema definitions may may look like:
+  - my_team/yasl
+    - main.yasl
+    - product.yasl
+    - features.yasl
+    - customers.yasl
+    - sales.yasl
+
+The `main.yasl` might only contain imports from other schema files.
+```yaml
+imports:
+  - product.yasl
+  - features.yasl
+  - customers.yasl
+  - sales.yasl
+```
+
+To validate data, you can simply point to the `main.yasl` as your schema and all other content will be integrated.  
+```bash
+yasl ./my_team/yasl/main.yasl ./data/my_data.yaml
+```
+
+But you do have the flexibility to just put things into a directory and use all yasl files in that directory if you choose.
+This would simply eliminate the `main.yasl` file from the structure above.
+To validate data you would point the yasl tool to the directory containing your schemas rather than a single 'entry point'.
+```bash
+yasl ./my_team/yasl ./data/my_data.yaml
+```
+
+### Metadata
+
+Metadata gives you the flexibility to capture relevant key-value pairs of data related to your schema.
+This information is not used by the yasl validation processes but is available for your use in parsing or using schema data.
+
+```yaml
+metadata:
+  author: John Doe
+  license:  Apache 2.0
+  version: 1.0.0
+definitions:
+  ...
+```
+
+### Namespaces
+
+YASL data type and eunumeration definitions are always defined within a namespace.
+A namespace is just a string value to support unique type naming.
+Namespaces permit the same type name to be used in different contexts without creating naming conflicts.
+
+```yaml
+definitions:
+  namespace_one:  # A namespace declaration.
+    types:
+      thing:  # A type name declearation.
+        ...
+  namespace_two:  # Another namespace declaration.
+    types:
+      thing:  # The same type name declaration, but differentiated by namespace.
+        ...
+```
+
+YASL will attempt to discover and use the correct type declaration based on context, but you can explicitly reference a type using it's namespace in a dot notation (i.e. `namespace_two.thing`) to avoid naming conflicts.
+Should a naming conflict arise, YASL will default to using the namespace of the referencing definition to resolve the conflict if possible.
+Other naming conflicts will result in an error that you must correct by resolving the conflict in your schema.
+
+### YASL Enumeration Definitions
+
+YASL enumerations are a simple way to establish prefined values as a usable type for use in schemas.
+
+An enumeration definition may look like...
+```yaml
+definitions:
+  balloon_city:
+    enums:
+      color:
+        values:
+          - RED
+          - BLUE
+          - GREEN
+      size:
+        values:
+          - SMALL
+          - MEDIUM
+          - LARGE
+```
+
+Once defined, enumerations can be used as types within type definitions.
+Here's an example of using the above enumerations as fields within a type definition.
+
+```yaml
+definitions:
+  balloon_city:
+    types:
+      baloon:
+        description: A baloon product.
+        properties:
+          brand:
+            type: str
+            description: The brand name of the baloon.
+          size:
+            type: size
+            description: The size of the baloon.
+          color:
+            type: color
+            description: The color of the baloon.
+```
+
+### YASL Type Definitions
+
+YASL intends to provide a simple but powerful means of defining complex data types for YAML data set validation.
+
+Types are defined under the `types` key in the schema file.
+Invididual types are captured as a map (or dict in python terms) with the type name being the key and the type attributes defined under that.
+
+These type definitions have the following attributes:
+
+- `description` (optional): str - A description of the type definition.
+- `properties`: property[] - List of data fields for the type.
+- `validators` (optional): validator - Special validators to establish field definition constraints.
+
+#### Type Properties
+
+Type definition properties allow you to establish the composition structure of YAML data within your YASL schema.
+Not only do these serve to support data validation, they also provide a method of data documentation.
+
+Properties are defined under the `properties` key in the type definition.
+Individual properties are captured as a map (or dict in python terms) with the property name being the key and the property attributes defined under that.
+
+Properties have the following attributes:
+
+- `type`: type - The name of the primitive, enumeration, or type definition of the field (may include namespace in dot-notation for clarity).
+- `description` (optional): str - A brief summary of the field.
+- `required` (optional): bool - True if the field must be present in the data set, false otherwise.  Default: true.
+- `unique` (optional): bool - True if the field must be unique across all type_def uses in the data set.  Default: false.
+- `default` (optional): any - The default value of the field if not provided.  The value type must match the type field.
+
+In addition to these fields, the primitive validators from above may be included as desired based on the type.
+
+Here's an example type definition:
+
+```yaml
+definitions:  # This is where we define our schema content.
+  acme:  # This is the namespace for the defined types and enums.
+    types:  # This is where we define our custom data types.
+      task:  # This is a data type named 'task'.
+        description: A thing to do.
+        properties:
+          description:
+            type: str
+            description: A description of the task.
+            required: true
+          owner:
+            type: str
+            description: The person responsible for the task.
+            required: false
+          complete:
+            type: bool
+            description: Is the task finished? True if yes, false if no.
+            required: true
+            default: false
+      list_of_tasks: # This is a data type named 'list_of_tasks'.
+        description: A list of tasks to complete.
+        properties:
+          task_list:
+            type: map[taskkey, task]
+            description: A list of tasks to do.
+            required: true
+
+    enums:  # This is where we define our enumerated types.
+      taskkey:  # This is the name of an enumerated type.
+        description: Allowed task names within the task_list.
+        values:
+          - task_01
+          - task_02
+          - task_03
+```
+
+#### Type Validators
+
+YASL recognizes there can be complexities and conditionals to consider when defining data types.
+Type validators allow you to establish constraints on your type definitions.
+The available validators provide for the basic definition of common data constraints in your schema.
+
+YASL provides the following type validators:
+
+- `only_one`: str[] - List of mutually exclusive property names where only one may be present.
+- `at_least_one`: str[] - List of property names where one or more must be present.
+- `if_then`: IfThen[] - List of conditional checks.
+  - `eval`: str - Name of a property in the `type_def`.
+  - `value`: str[] - List of values to compare to `eval` for equivalence (i.e. `true` for a bool, `42` for int, etc.).
+  - `present`: str[] (optional) - list of property names in the `type_def` that must be present if the check is `true`.
+  - `absent`: str[] (optional) - list of property names in the `type_def` that must be absent of the check is `true`.  Default: none.
 
 ### YASL Primitives
 
@@ -195,129 +409,4 @@ Any validators include:
 
 YASL supports all [Pydantic types](https://docs.pydantic.dev/latest/api/types/) [and Pydantic Network types](https://docs.pydantic.dev/latest/api/networks/).
 
-### YASL Enumeration Definitions
 
-YASL enumerations are a simple way to establish prefined values as a usable type for use in schemas.
-
-An enumeration definition may look like...
-```yaml
-enums:
-  color:
-    values:
-      - RED
-      - BLUE
-      - GREEN
-  size:
-    values:
-      - SMALL
-      - MEDIUM
-      - LARGE
-```
-
-Once defined, enumerations can be used as types within type definitions.
-Here's an example of using the above enumerations as fields within a type definition.
-
-```yaml
-types:
-  baloon:
-    description: A baloon product.
-    fields:
-      brand:
-        type: str
-        description: The brand name of the baloon.
-      size:
-        type: size
-        description: The size of the baloon.
-      color:
-        type: color
-        description: The color of the baloon.
-```
-
-### YASL Type Definitions
-
-YASL intends to provide a simple but powerful means of defining complex data types for YAML data set validation.
-
-Types are defined under the `types` key in the schema file.
-Invididual types are captured as a map (or dict in python terms) with the type name being the key and the type attributes defined under that.
-
-These type definitions have the following attributes:
-
-- `namespace` (optional): str - Establishes a named context for the type within which it must be unique.
-- `description` (optional): str - A description of the type definition.
-- `properties`: property[] - List of data fields for the type.
-- `validators` (optional): validator - Special validators to establish field definition constraints.
-
-### Type Properties
-
-Type definition properties allow you to establish the composition structure of YAML data within your YASL schema.
-Not only do these serve to support data validation, they also provide a method of data documentation.
-
-Properties are defined under the `properties` key in the type definition.
-Individual properties are captured as a map (or dict in python terms) with the property name being the key and the property attributes defined under that.
-
-Properties have the following attributes:
-
-- `namespace` (optional): str - The namespace containing the type definition if not using primitive types.  Default: same package as the type_def.
-- `type`: type - The name of the primitive, enumeration, or type definition of the field.
-- `description` (optional): str - A brief summary of the field.
-- `required` (optional): bool - True if the field must be present in the data set, false otherwise.  Default: true.
-- `unique` (optional): bool - True if the field must be unique across all type_def uses in the data set.  Default: false.
-- `default` (optional): any - The default value of the field if not provided.  The value type must match the type field.
-
-In addition to these fields, the primitive validators from above may be included as desired based on the type.
-
-Here's an example type definition:
-
-```yaml
-types:
-  task:
-    description: A thing to do.
-    namespace: dynamic
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
-  list_of_tasks:
-    description: A list of tasks to complete.
-    namespace: dynamic
-    properties:
-      task_list:
-        type: map[taskkey, task]
-        description: A list of tasks to do.
-        required: true
-
-enums:
-  taskkey:
-    namespace: acme
-    description: The type of shape.
-    values:
-      - task_01
-      - task_02
-      - task_03
-```
-
-### Type Validators
-
-YASL recognizes there can be complexities and conditionals to consider when defining data types.
-Type validators allow you to establish constraints on your type definitions.
-The available validators provide for the basic definition of common data constraints in your schema.
-
-YASL provides the following type validators:
-
-- `only_one`: str[] - List of mutually exclusive property names where only one may be present.
-- `at_least_one`: str[] - List of property names where one or more must be present.
-- `if_then`: IfThen[] - List of conditional checks.
-  - `eval`: str - Name of a property in the `type_def`.
-  - `value`: str[] - List of values to compare to `eval` for equivalence (i.e. `true` for a bool, `42` for int, etc.).
-  - `present`: str[] (optional) - list of property names in the `type_def` that must be present if the check is `true`.
-  - `absent`: str[] (optional) - list of property names in the `type_def` that must be absent of the check is `true`.  Default: none.

--- a/src/yasl/cache.py
+++ b/src/yasl/cache.py
@@ -22,7 +22,7 @@ class YaslRegistry:
         self.yasl_enumerations: Dict[Tuple[str, Optional[str]], Type[Enum]] = {}
         self.unique_values_store: Dict[Tuple[str, Optional[str]], Dict[str, set]] = {}
 
-    def register_type(self, name: str, type_def: Type[BaseModel], namespace: Optional[str] = None) -> None:
+    def register_type(self, name: str, type_def: Type[BaseModel], namespace: str) -> None:
         key = (name, namespace)
         log = logging.getLogger("yasl")
         if key in self.yasl_type_defs:
@@ -32,7 +32,7 @@ class YaslRegistry:
 
     def get_type(self, name: str, namespace: Optional[str] = None, default_namespace: Optional[str] = None) -> Optional[Type[BaseModel]]:
         log = logging.getLogger("yasl")
-        log.debug(f"Looking up type '{name}' in namespace '{namespace}'")
+        log.debug(f"Looking up type '{name}' in namespace '{namespace}' with default namespace '{default_namespace}'")
         if namespace is not None:
             key = (name, namespace)
             if key in self.yasl_type_defs:
@@ -52,7 +52,7 @@ class YaslRegistry:
             f"Ambiguous type name '{name}': found in multiple namespaces {matches}. Specify a namespace."
         )
 
-    def register_enum(self, name: str, enum_def: Type[Enum], namespace: Optional[str] = None) -> None:
+    def register_enum(self, name: str, enum_def: Type[Enum], namespace: str) -> None:
         log = logging.getLogger("yasl")
         key = (name, namespace)
         if key in self.yasl_enumerations:
@@ -65,7 +65,7 @@ class YaslRegistry:
 
     def get_enum(self, name: str, namespace: Optional[str] = None, default_namespace: Optional[str] = None) -> Optional[Type[Enum]]:
         log = logging.getLogger("yasl")
-        log.debug(f"Looking up enum '{name}' in namespace '{namespace}'")
+        log.debug(f"Looking up enum '{name}' in namespace '{namespace}' with default namespace '{default_namespace}'")
         if namespace is not None:
             key = (name, namespace)
             if key in self.yasl_enumerations:

--- a/src/yasl/cli.py
+++ b/src/yasl/cli.py
@@ -15,17 +15,17 @@ def main():
     parser.add_argument(
         "schema",
         nargs="?",
-        help="YASL schema file",
+        help="YASL schema file or directory",
     )
     parser.add_argument(
         "yaml",
         nargs="?",
-        help="YAML data file",
+        help="YAML data file or directory",
     )
     parser.add_argument(
         "model_name",
         nargs="?",
-        help="YASL schema name for the yaml data file (optional)",
+        help="YASL schema type name for the yaml data file (optional)",
     )
     parser.add_argument(
         "--version", action="store_true", help="Show version information and exit"

--- a/src/yasl/pydantic_types.py
+++ b/src/yasl/pydantic_types.py
@@ -104,5 +104,5 @@ class YaslItem(YASLBaseModel):
 class YaslRoot(YASLBaseModel):
     imports: Optional[List[str]] = None
     metadata: Optional[Dict[str, Any]] = None
-    definitions: Dict[str, YaslItem]
+    definitions: Optional[Dict[str, YaslItem]] = None
     model_config = {"extra": "forbid"}

--- a/src/yasl/pydantic_types.py
+++ b/src/yasl/pydantic_types.py
@@ -14,7 +14,6 @@ class YASLBaseModel(BaseModel):
 class Enumeration(YASLBaseModel):
     # name: str
     description: Optional[str] = None
-    namespace: Optional[str] = None
     values: List[str]
 
     model_config = {"extra": "forbid"}
@@ -23,7 +22,6 @@ class Enumeration(YASLBaseModel):
 class Property(YASLBaseModel):
     # name: str
     type: str
-    namespace: Optional[str] = None
     description: Optional[str] = None
     required: Optional[bool] = True
     unique: Optional[bool] = False
@@ -97,9 +95,14 @@ class TypeDef(YASLBaseModel):
 
     model_config = {"extra": "forbid"}
 
-class YaslRoot(YASLBaseModel):
-    imports: Optional[List[str]] = None
+class YaslItem(YASLBaseModel):
+    description: Optional[str] = None
     enums: Optional[Dict[str, Enumeration]] = None
     types: Optional[Dict[str, TypeDef]] = None
+    model_config = {"extra": "forbid"}
 
+class YaslRoot(YASLBaseModel):
+    imports: Optional[List[str]] = None
+    metadata: Optional[Dict[str, Any]] = None
+    definitions: Dict[str, YaslItem]
     model_config = {"extra": "forbid"}

--- a/src/yasl/validators.py
+++ b/src/yasl/validators.py
@@ -224,7 +224,7 @@ def markdown_validator(cls, value: str):
     except Exception:
         raise ValueError("Markdown content is not valid.") 
 
-def property_validator_factory(typedef_name: str, type_def: TypeDef, property_name: str, property: Property) -> Callable:
+def property_validator_factory(typedef_name: str, type_namespace: str, type_def: TypeDef, property_name: str, property: Property) -> Callable:
     validators = []
     # list validators
     if property.list_min is not None:
@@ -234,7 +234,11 @@ def property_validator_factory(typedef_name: str, type_def: TypeDef, property_na
 
     # unique validator
     if property.unique:
-        validators.append(partial(unique_value_validator, type_name=typedef_name, property_name=property_name, type_namespace=type_def.namespace))
+        if "." in property_name:
+            property_namespace, property_name = property_name.rsplit('.', 1)
+        else:
+            property_namespace = type_namespace
+        validators.append(partial(unique_value_validator, type_name=typedef_name, property_name=property_name, type_namespace=property_namespace))
 
     # numeric validators
     if property.gt is not None:

--- a/tests/yasl/schema_data.py
+++ b/tests/yasl/schema_data.py
@@ -1,0 +1,798 @@
+CUSTOMER_LIST_YASL = """
+definitions:
+  acme:
+    description: Acme Corporation schema definitions.
+    enums:
+      customer_status:
+        description: The status of the customer.
+        values:
+          - active
+          - inactive
+    types:
+      customer:
+        description: Information about a customer.
+        properties:
+          name:
+            type: str
+            description: The customer's name.
+            required: true
+            unique: true
+          age:
+            type: int
+            description: The customer's age.
+            required: false
+          email:
+            type: str
+            description:  The customer's email address.
+            required: true
+          status:
+            type: customer_status
+            description: The customer's status.
+            required: true
+      customer_list:
+        description: A list of customers.
+        properties:
+          customers:
+            type: customer[]
+            description: Information about a customer.
+            list_min: 2
+            list_max: 3
+      account:
+        description: Information about an account.
+        properties:
+          id:
+            type: str
+            description: The unique identifier for the account.
+            required: true
+          account_rep:
+            type: str
+            description: The name of the account representative.
+            required: true
+          customer_name:
+            type: ref[customer.name]
+            description: The name of the customer associated with the account.
+            required: true
+      business:
+        description: A list of accounts.
+        properties:
+          business_name:
+            type: str
+            description: The name of the business.
+            required: true
+          customers:
+            type: customer[]
+            description: Information about a list of customers.
+            required: true
+          accounts:
+            type: account[]
+            description: Information about an account.
+            required: true
+"""
+
+NAMESPACE_CUSTOMER_LIST_YASL = """
+definitions:
+    acme:
+        description: Acme Corporation schema definitions.
+        enums:
+            customer_status:
+                description: The status of the customer.
+                values:
+                    - active
+                    - inactive
+        types:
+            customer:
+                description: Information about a customer.
+                properties:
+                    name:
+                        type: str
+                        description: The customer's name.
+                        required: true
+                        unique: true
+                    age:
+                        type: int
+                        description: The customer's age.
+                        required: false
+                    email:
+                        type: str
+                        description:  The customer's email address.
+                        required: true
+                    status:
+                        type: customer_status
+                        description: The customer's status.
+                        required: true
+            customer_list:
+                description: A list of customers.
+                properties:
+                    customers:
+                        type: acme.customer[]
+                        description: Information about a customer.
+                        list_min: 2
+                        list_max: 3
+            account:
+                description: Information about an account.
+                properties:
+                    id:
+                        type: str
+                        description: The unique identifier for the account.
+                        required: true
+                    account_rep:
+                        type: str
+                        description: The name of the account representative.
+                        required: true
+                    customer_name:
+                        type: ref[acme.customer.name]
+                        description: The name of the customer associated with the account.
+                        required: true
+            business:
+                description: A list of accounts.
+                properties:
+                    business_name:
+                        type: str
+                        description: The name of the business.
+                        required: true
+                    customers:
+                        type: acme.customer[]
+                        description: Information about a list of customers.
+                        required: true
+                    accounts:
+                        type: acme.account[]
+                        description: Information about an account.
+                        required: true
+"""
+
+PERSON_YASL = """
+definitions:
+    acme:
+        description: Acme Corporation schema definitions.
+        types:
+            person:
+                description: Information about a person.
+                properties:
+                    name:
+                        type: str
+                        description: The person's name.
+                        required: true
+                        str_min: 5
+                        str_max: 15
+                        str_regex: '^[A-Za-z ]+$'
+                    age:
+                        type: int
+                        description: The person's age.
+                        required: true
+                        ge: 18
+                        lt: 125
+                        whole_number: true
+                        multiple_of: 2
+                        exclude:
+                            - 64
+                    birthday:
+                        type: date
+                        description: The person's birthday.
+                        required: false
+                        after: "1900-01-01"
+                        before: "2050-12-31"
+                    favorite_time:
+                        type: time
+                        description: The person's favorite time of day.
+                        required: false
+                    office:
+                        type: any
+                        description: The person's office number, or true / false to indicate need.
+                        required: false
+                        any_of:
+                            - int
+                            - bool
+                    bio:
+                        type: path
+                        description: Path to a bio file.
+                        required: false
+                        is_file: true
+                        path_exists: false
+                        file_ext:
+                            - txt
+                            - md
+                    home_directory:
+                        type: path
+                        description: Path to the person's home directory.
+                        required: false
+                        is_dir: true
+                        path_exists: true
+                    website:
+                        type: url
+                        description: The person's website.
+                        required: false
+                        url_base: www.example.com
+                        url_protocols:
+                            - http
+                            - https
+"""
+
+PERSON_WEBSITE_REACHABLE_YAML = """
+definitions:
+    acme:
+        description: Acme Corporation schema definitions.
+        types:
+            person:
+                description: Information about a person.
+                properties:
+                    name:
+                        type: str
+                        description: The person's name.
+                        required: true
+                        str_min: 5
+                        str_max: 15
+                        str_regex: '^[A-Za-z ]+$'
+                    website:
+                        type: url
+                        description: The person's website.
+                        required: false
+                        url_reachable: true
+"""
+
+SHAPE_YASL = """
+definitions:
+  acme:
+    types:
+      shape:
+        description: Information about a shape.
+        properties:
+          name:
+              type: str
+              description: The name of the shape.
+              required: true
+          type:
+              type: ShapeType
+              description: The type of shape.
+              required: true
+          radius:
+              type: float
+              description: The radius of the circle.
+              required: false
+              gt: 0
+          side_length:
+              type: float
+              description: The length of the side of the square or triangle.
+              required: false
+              gt: 0
+          color:
+              type: str
+              description: The color of the shape.
+              required: false
+          colour:
+              type: str
+              description: The color of the shape (British spelling).
+              required: false
+          location:
+              type: str
+              description: The location of the shape.
+              required: false
+          orientation:
+              type: str
+              description: The orientation of the shape.
+              required: false
+        validators:
+          only_one:
+            - color
+            - colour
+          at_least_one:
+            - location
+            - orientation
+          if_then:
+            - eval: type
+              value: 
+                - circle
+              present:
+                - radius
+              absent:
+                - side_length
+            - eval: type
+              value: 
+                - square
+                - triangle
+              present:
+                - side_length
+              absent:
+                - radius
+    enums:
+      ShapeType:
+        description: The type of shape.
+        values:
+          - circle
+          - square
+          - triangle
+"""
+
+TODO_YASL = """
+definitions:
+    dynamic:
+        types:
+            task:
+                description: A thing to do.
+                properties:
+                    description:
+                        type: str
+                        description: A description of the task.
+                        required: true
+                    owner:
+                        type: str
+                        description: The person responsible for the task.
+                        required: false
+                    complete:
+                        type: bool
+                        description: Is the task finished? True if yes, false if no.
+                        required: true
+                        default: false
+            list_of_tasks:
+                description: A list of tasks to complete.
+                properties:
+                    task_list:
+                        type: map[str, task]
+                        description: A list of tasks to do.
+                        required: true
+"""
+
+TODO_ENUM_MAP_YASL = """
+definitions:
+    dynamic:
+        types:
+            task:
+                description: A thing to do.
+                properties:
+                    description:
+                        type: str
+                        description: A description of the task.
+                        required: true
+                    owner:
+                        type: str
+                        description: The person responsible for the task.
+                        required: false
+                    complete:
+                        type: bool
+                        description: Is the task finished? True if yes, false if no.
+                        required: true
+                        default: false
+            list_of_tasks:
+                description: A list of tasks to complete.
+                properties:
+                    task_list:
+                        type: map[taskkey, task]
+                        description: A list of tasks to do.
+                        required: true
+        enums:
+            taskkey:
+                description: The type of shape.
+                values:
+                - task_01
+                - task_02
+"""
+
+TODO_MIXED_NAMESPACE_YASL = """
+definitions:
+    something:
+        types:
+            task:
+                description: A thing to do.
+                properties:
+                    description:
+                        type: str
+                        description: A description of the task.
+                        required: true
+                    owner:
+                        type: str
+                        description: The person responsible for the task.
+                        required: false
+                    complete:
+                        type: bool
+                        description: Is the task finished? True if yes, false if no.
+                        required: true
+                        default: false
+    dynamic:
+        types:
+            list_of_tasks:
+                description: A list of tasks to complete.
+                properties:
+                    task_list:
+                        type: map[other.taskkey, something.task]
+                        description: A list of tasks to do.
+                        required: true
+    other:
+        enums:
+            taskkey:
+                description: The type of task.
+                values:
+                - task_01
+                - task_02
+                - task_03
+"""
+
+TODO_NESTED_MAP_YASL = """
+definitions:
+    dynamic:
+        types:
+            task:
+                description: A thing to do.
+                properties:
+                    description:
+                        type: str
+                        description: A description of the task.
+                        required: true
+                    owner:
+                        type: str
+                        description: The person responsible for the task.
+                        required: false
+                    complete:
+                        type: bool
+                        description: Is the task finished? True if yes, false if no.
+                        required: true
+                        default: false
+            feature:
+                description: A list of tasks to complete.
+                properties:
+                    feature:
+                        type: str
+                        description: The feature name.
+                        required: true
+                    task_list:
+                        type: map[str, task]
+                        description: A list of tasks to do.
+                        required: true
+            project:
+                description: A project with tasks.
+                properties:
+                    project_name:
+                        type: str
+                        description: The name of the project.
+                        required: true
+                    features:
+                        type: feature[]
+                        description: The tasks for the project.
+                        required: true
+"""
+
+TODO_INT_MAP_YASL = """
+definitions:
+    dynamic:
+        types:
+            task:
+                description: A thing to do.
+                namespace: dynamic
+                properties:
+                    description:
+                        type: str
+                        description: A description of the task.
+                        required: true
+                    owner:
+                        type: str
+                        description: The person responsible for the task.
+                        required: false
+                    complete:
+                        type: bool
+                        description: Is the task finished? True if yes, false if no.
+                        required: true
+                        default: false
+            list_of_tasks:
+                description: A list of tasks to complete.
+                namespace: dynamic
+                properties:
+                    task_list:
+                        type: map[int, task]
+                        description: A list of tasks to do.
+                        required: true
+"""
+
+TODO_BOOL_MAP_YASL = """
+definitions:
+    dynamic:
+        types:
+            task:
+                description: A thing to do.
+                namespace: dynamic
+                properties:
+                    description:
+                        type: str
+                        description: A description of the task.
+                        required: true
+                    owner:
+                        type: str
+                        description: The person responsible for the task.
+                        required: false
+                    complete:
+                        type: bool
+                        description: Is the task finished? True if yes, false if no.
+                        required: true
+                        default: false
+            list_of_tasks:
+                description: A list of tasks to complete.
+                namespace: dynamic
+                properties:
+                    task_list:
+                        type: map[bool, task]
+                        description: A list of tasks to do.
+                        required: true
+"""
+
+TODO_BAD_MAP_VALUE_YASL = """
+definitions:
+    dynamic:
+        types:
+            task:
+                description: A thing to do.
+                namespace: dynamic
+                properties:
+                    description:
+                        type: str
+                        description: A description of the task.
+                        required: true
+                    owner:
+                        type: str
+                        description: The person responsible for the task.
+                        required: false
+                    complete:
+                        type: bool
+                        description: Is the task finished? True if yes, false if no.
+                        required: true
+                        default: false
+            list_of_tasks:
+                description: A list of tasks to complete.
+                namespace: dynamic
+                properties:
+                    task_list:
+                        type: map[str, junktask]
+                        description: A list of tasks to do.
+                        required: true
+"""
+
+PYDANTIC_TYPES_YASL = """
+definitions:
+    pydantic:
+        types:
+            thing:
+                description: Information about a thing.
+                properties:
+                    id:
+                        type: str
+                        description: The unique identifier for the thing.
+                        required: true
+                    strict_bool:
+                        type: StrictBool
+                        description: A strict boolean value.
+                        required: false
+                    markdown:
+                        type: markdown
+                        description: A markdown value
+                        required: false
+                    positive_int:
+                        type: PositiveInt
+                        description: A positive integer value.
+                        required: false
+                    negative_int:
+                        type: NegativeInt
+                        description: A negative integer value.
+                        required: false
+                    non_positive_int:
+                        type: NonPositiveInt
+                        description: A non-positive integer value.
+                        required: false
+                    non_negative_int:
+                        type: NonNegativeInt
+                        description: A non-negative integer value.
+                        required: false
+                    strict_int:
+                        type: StrictInt
+                        description: A strict integer value.
+                        required: false
+                    positive_float:
+                        type: PositiveFloat
+                        description: A positive float value.
+                        required: false
+                    negative_float:
+                        type: NegativeFloat
+                        description: A negative float value.
+                        required: false
+                    non_positive_float:
+                        type: NonPositiveFloat
+                        description: A non-positive float value.
+                        required: false
+                    non_negative_float:
+                        type: NonNegativeFloat
+                        description: A non-negative float value.
+                        required: false
+                    strict_float:
+                        type: StrictFloat
+                        description: A strict float value.
+                        required: false
+                    finite_float:
+                        type: FiniteFloat
+                        description: A finite float value (not NaN or infinite).
+                        required: false
+                    strict_str:
+                        type: StrictStr
+                        description: A strict string value.
+                        required: false
+                    uuid1:
+                        type: UUID1
+                        description: A UUID version 1.
+                        required: false
+                    uuid3:
+                        type: UUID3
+                        description: A UUID version 3.
+                        required: false
+                    uuid4:
+                        type: UUID4
+                        description: A UUID version 4.
+                        required: false
+                    uuid5:
+                        type: UUID5
+                        description: A UUID version 5.
+                        required: false
+                    uuid6:
+                        type: UUID6
+                        description: A UUID version 6.
+                        required: false
+                    uuid7:
+                        type: UUID7
+                        description: A UUID version 7.
+                        required: false
+                    uuid8:
+                        type: UUID8
+                        description: A UUID version 8.
+                        required: false
+                    file_path:
+                        type: FilePath
+                        description: A valid file path.
+                        required: false
+                    directory_path:
+                        type: DirectoryPath
+                        description: A valid directory path.
+                        required: false
+                    base64_bytes:
+                        type: Base64Bytes
+                        description: A base64 encoded byte string.
+                        required: false
+                    base64_str:
+                        type: Base64Str
+                        description: A base64 encoded string.
+                        required: false
+                    base64_url_bytes:
+                        type: Base64UrlBytes
+                        description: A base64 URL-safe encoded byte string.
+                        required: false
+                    base64_url_str:
+                        type: Base64UrlStr
+                        description: A base64 URL-safe encoded string.
+                        required: false
+                    any_url:
+                        type: AnyUrl
+                        description: Any valid URL.
+                        required: false
+                    any_http_url:
+                        type: AnyHttpUrl
+                        description: Any valid HTTP or HTTPS URL.
+                        required: false
+                    http_url:
+                        type: HttpUrl
+                        description: A valid HTTP or HTTPS URL.
+                        required: false
+                    any_websocket_url:
+                        type: AnyWebsocketUrl
+                        description: Any valid WebSocket or secure WebSocket URL.
+                        required: false
+                    websocket_url:
+                        type: WebsocketUrl
+                        description: A valid WebSocket or secure WebSocket URL.
+                        required: false
+                    file_url:
+                        type: FileUrl
+                        description: A valid file URL.
+                        required: false
+                    ftp_url:
+                        type: FtpUrl
+                        description: A valid FTP or FTPS URL.
+                        required: false
+                    postgres_dsn:
+                        type: PostgresDsn
+                        description: A valid PostgreSQL DSN.
+                        required: false
+                    cockroach_dsn:
+                        type: CockroachDsn
+                        description: A valid CockroachDB DSN.
+                        required: false
+                    amqp_dsn:
+                        type: AmqpDsn
+                        description: A valid AMQP DSN.
+                        required: false
+                    redis_dsn:
+                        type: RedisDsn
+                        description: A valid Redis DSN.
+                        required: false
+                    mongo_dsn:
+                        type: MongoDsn
+                        description: A valid MongoDB DSN.
+                        required: false
+                    kafka_dsn:
+                        type: KafkaDsn
+                        description: A valid Kafka DSN.
+                        required: false
+                    nats_dsn:
+                        type: NatsDsn
+                        description: A valid NATS DSN.
+                        required: false
+                    mysql_dsn:
+                        type: MySQLDsn
+                        description: A valid MySQL DSN.
+                        required: false
+                    mariadb_dsn:
+                        type: MariaDBDsn
+                        description: A valid MariaDB DSN.
+                        required: false
+                    clickhouse_dsn:
+                        type: ClickHouseDsn
+                        description: A valid ClickHouse DSN.
+                        required: false
+                    snowflake_dsn:
+                        type: SnowflakeDsn
+                        description: A valid Snowflake DSN.
+                        required: false
+                    email_str:
+                        type: EmailStr
+                        description: A valid email address.
+                        required: false
+                    name_email:
+                        type: NameEmail
+                        description: A valid name and email address.
+                        required: false
+                    ipvany_address:
+                        type: IPvAnyAddress
+                        description: A valid IPv4 or IPv6 address.
+                        required: false
+"""
+
+MARKDOWN_YASL = """
+definitions:
+    acme:
+        types:
+            thing:
+                description: Information about a thing.
+                properties:
+                    id:
+                        type: str
+                        description: The unique identifier for the thing.
+                        required: true
+                    markdown:
+                        type: markdown
+                        description: A markdown value
+                        required: true
+"""
+
+TASK_BAD_NAMESPACE_REF_YASL = """
+definitions:
+    main:
+        types:
+            task:
+                description: A thing to do.
+                namespace: main
+                properties:
+                    description:
+                        type: str
+                        description: A description of the task.
+                        required: true
+                    owner:
+                        type: str
+                        description: The person responsible for the task.
+                        required: false
+                    complete:
+                        type: bool
+                        description: Is the task finished? True if yes, false if no.
+                        required: true
+                        default: false
+    other:
+        types:
+            list_of_tasks:
+                description: A list of tasks to complete.
+                namespace: other
+                properties:
+                    task_list:
+                        type: map[int, notmain.task]
+                        description: A list of tasks to do.
+                        required: true
+"""

--- a/tests/yasl/test_yasl.py
+++ b/tests/yasl/test_yasl.py
@@ -10,320 +10,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 from yasl import yasl_eval
 from yasl.cli import main as yasl_cli_main
 
-CUSTOMER_LIST_YASL = """
-enums:
-  customer_status:
-    namespace: acme
-    description: The status of the customer.
-    values:
-      - active
-      - inactive
-types:
-  customer:
-    namespace: acme
-    description: Information about a customer.
-    properties:
-      name:
-        type: str
-        description: The customer's name.
-        required: true
-        unique: true
-      age:
-        type: int
-        description: The customer's age.
-        required: false
-      email:
-        type: str
-        description:  The customer's email address.
-        required: true
-      status:
-        type: customer_status
-        namespace: acme
-        description: The customer's status.
-        required: true
-  customer_list:
-    namespace: acme
-    description: A list of customers.
-    properties:
-      customers:
-        type: customer[]
-        description: Information about a customer.
-        list_min: 2
-        list_max: 3
-  account:
-    namespace: acme
-    description: Information about an account.
-    properties:
-      id:
-        type: str
-        description: The unique identifier for the account.
-        required: true
-      account_rep:
-        type: str
-        description: The name of the account representative.
-        required: true
-      customer_name:
-        type: ref[customer.name]
-        description: The name of the customer associated with the account.
-        required: true
-  business:
-    namespace: acme
-    description: A list of accounts.
-    properties:
-      business_name:
-        type: str
-        description: The name of the business.
-        required: true
-      customers:
-        type: customer[]
-        description: Information about a list of customers.
-        required: true
-      accounts:
-        type: account[]
-        description: Information about an account.
-        required: true
-"""
-
-NAMESPACE_CUSTOMER_LIST_YASL = """
-enums:
-  customer_status:
-    namespace: acme
-    description: The status of the customer.
-    values:
-      - active
-      - inactive
-types:
-  customer:
-    namespace: acme
-    description: Information about a customer.
-    properties:
-      name:
-        type: str
-        description: The customer's name.
-        required: true
-        unique: true
-      age:
-        type: int
-        description: The customer's age.
-        required: false
-      email:
-        type: str
-        description:  The customer's email address.
-        required: true
-      status:
-        type: customer_status
-        namespace: acme
-        description: The customer's status.
-        required: true
-  customer_list:
-    namespace: acme
-    description: A list of customers.
-    properties:
-      customers:
-        type: acme.customer[]
-        description: Information about a customer.
-        list_min: 2
-        list_max: 3
-  account:
-    namespace: acme
-    description: Information about an account.
-    properties:
-      id:
-        type: str
-        description: The unique identifier for the account.
-        required: true
-      account_rep:
-        type: str
-        description: The name of the account representative.
-        required: true
-      customer_name:
-        type: ref[acme.customer.name]
-        description: The name of the customer associated with the account.
-        required: true
-  business:
-    namespace: acme
-    description: A list of accounts.
-    properties:
-      business_name:
-        type: str
-        description: The name of the business.
-        required: true
-      customers:
-        type: acme.customer[]
-        description: Information about a list of customers.
-        required: true
-      accounts:
-        type: acme.account[]
-        description: Information about an account.
-        required: true
-"""
-
-PERSON_YASL = """
-types:
-  person:
-    namespace: acme
-    description: Information about a person.
-    properties:
-      name:
-        type: str
-        description: The person's name.
-        required: true
-        str_min: 5
-        str_max: 15
-        str_regex: '^[A-Za-z ]+$'
-      age:
-        type: int
-        description: The person's age.
-        required: true
-        ge: 18
-        lt: 125
-        whole_number: true
-        multiple_of: 2
-        exclude:
-            - 64
-      birthday:
-        type: date
-        description: The person's birthday.
-        required: false
-        after: "1900-01-01"
-        before: "2050-12-31"
-      favorite_time:
-        type: time
-        description: The person's favorite time of day.
-        required: false
-      office:
-        type: any
-        description: The person's office number, or true / false to indicate need.
-        required: false
-        any_of:
-          - int
-          - bool
-      bio:
-        type: path
-        description: Path to a bio file.
-        required: false
-        is_file: true
-        path_exists: false
-        file_ext:
-          - txt
-          - md
-      home_directory:
-        type: path
-        description: Path to the person's home directory.
-        required: false
-        is_dir: true
-        path_exists: true
-      website:
-        type: url
-        description: The person's website.
-        required: false
-        url_base: www.example.com
-        url_protocols:
-          - http
-          - https
-"""
-
-SHAPE_YASL = """
-types:
-  shape:
-    namespace: acme
-    description: Information about a shape.
-    properties:
-      name:
-        type: str
-        description: The name of the shape.
-        required: true
-      type:
-        type: ShapeType
-        description: The type of shape.
-        required: true
-      radius:
-        type: float
-        description: The radius of the circle.
-        required: false
-        gt: 0
-      side_length:
-        type: float
-        description: The length of the side of the square or triangle.
-        required: false
-        gt: 0
-      color:
-        type: str
-        description: The color of the shape.
-        required: false
-      colour:
-        type: str
-        description: The color of the shape (British spelling).
-        required: false
-      location:
-        type: str
-        description: The location of the shape.
-        required: false
-      orientation:
-        type: str
-        description: The orientation of the shape.
-        required: false
-    validators:
-      only_one:
-        - color
-        - colour
-      at_least_one:
-        - location
-        - orientation
-      if_then:
-        - eval: type
-          value: 
-           - circle
-          present:
-            - radius
-          absent:
-            - side_length
-        - eval: type
-          value: 
-            - square
-            - triangle
-          present:
-            - side_length
-          absent:
-            - radius
-enums:
-  ShapeType:
-    namespace: acme
-    description: The type of shape.
-    values:
-      - circle
-      - square
-      - triangle
-"""
-
-TODO_YASL = """
-types:
-  task:
-    description: A thing to do.
-    namespace: dynamic
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
-  list_of_tasks:
-    description: A list of tasks to complete.
-    namespace: dynamic
-    properties:
-      task_list:
-        type: map[str, task]
-        description: A list of tasks to do.
-        required: true
-"""
+from schema_data import MARKDOWN_YASL, PERSON_WEBSITE_REACHABLE_YAML, PYDANTIC_TYPES_YASL, TASK_BAD_NAMESPACE_REF_YASL, TODO_BAD_MAP_VALUE_YASL, TODO_BOOL_MAP_YASL, TODO_ENUM_MAP_YASL, TODO_INT_MAP_YASL, TODO_MIXED_NAMESPACE_YASL, TODO_NESTED_MAP_YASL, TODO_YASL, PERSON_YASL, SHAPE_YASL, CUSTOMER_LIST_YASL, NAMESPACE_CUSTOMER_LIST_YASL
 
 def run_cli(args):
     filtered_args = [item for item in args if item is not None]
@@ -768,25 +455,7 @@ website: ftp://www.example.com/joe_smith
     run_eval_command(yaml_data, yasl_schema, "person", False)
 
 def test_eval_website_reachable():
-    yasl_schema = """
-types:
-  person:
-    namespace: acme
-    description: Information about a person.
-    properties:
-      name:
-        type: str
-        description: The person's name.
-        required: true
-        str_min: 5
-        str_max: 15
-        str_regex: '^[A-Za-z ]+$'
-      website:
-        type: url
-        description: The person's website.
-        required: false
-        url_reachable: true
-"""
+    yasl_schema = PERSON_WEBSITE_REACHABLE_YAML
     yaml_data = """
 name: Joe Smith
 website: https://www.google.com
@@ -871,209 +540,7 @@ def test_version_command():
     assert "YASL version" in result.stdout
 
 def test_pydantic_types():
-    yasl = """
-types:
-  thing:
-    namespace: acme
-    description: Information about a thing.
-    properties:
-      id:
-        type: str
-        description: The unique identifier for the thing.
-        required: true
-      strict_bool:
-        type: StrictBool
-        description: A strict boolean value.
-        required: false
-      markdown:
-        type: markdown
-        description: A markdown value
-        required: false
-      positive_int:
-        type: PositiveInt
-        description: A positive integer value.
-        required: false
-      negative_int:
-        type: NegativeInt
-        description: A negative integer value.
-        required: false
-      non_positive_int:
-        type: NonPositiveInt
-        description: A non-positive integer value.
-        required: false
-      non_negative_int:
-        type: NonNegativeInt
-        description: A non-negative integer value.
-        required: false
-      strict_int:
-        type: StrictInt
-        description: A strict integer value.
-        required: false
-      positive_float:
-        type: PositiveFloat
-        description: A positive float value.
-        required: false
-      negative_float:
-        type: NegativeFloat
-        description: A negative float value.
-        required: false
-      non_positive_float:
-        type: NonPositiveFloat
-        description: A non-positive float value.
-        required: false
-      non_negative_float:
-        type: NonNegativeFloat
-        description: A non-negative float value.
-        required: false
-      strict_float:
-        type: StrictFloat
-        description: A strict float value.
-        required: false
-      finite_float:
-        type: FiniteFloat
-        description: A finite float value (not NaN or infinite).
-        required: false
-      strict_str:
-        type: StrictStr
-        description: A strict string value.
-        required: false
-      uuid1:
-        type: UUID1
-        description: A UUID version 1.
-        required: false
-      uuid3:
-        type: UUID3
-        description: A UUID version 3.
-        required: false
-      uuid4:
-        type: UUID4
-        description: A UUID version 4.
-        required: false
-      uuid5:
-        type: UUID5
-        description: A UUID version 5.
-        required: false
-      uuid6:
-        type: UUID6
-        description: A UUID version 6.
-        required: false
-      uuid7:
-        type: UUID7
-        description: A UUID version 7.
-        required: false
-      uuid8:
-        type: UUID8
-        description: A UUID version 8.
-        required: false
-      file_path:
-        type: FilePath
-        description: A valid file path.
-        required: false
-      directory_path:
-        type: DirectoryPath
-        description: A valid directory path.
-        required: false
-      base64_bytes:
-        type: Base64Bytes
-        description: A base64 encoded byte string.
-        required: false
-      base64_str:
-        type: Base64Str
-        description: A base64 encoded string.
-        required: false
-      base64_url_bytes:
-        type: Base64UrlBytes
-        description: A base64 URL-safe encoded byte string.
-        required: false
-      base64_url_str:
-        type: Base64UrlStr
-        description: A base64 URL-safe encoded string.
-        required: false
-      any_url:
-        type: AnyUrl
-        description: Any valid URL.
-        required: false
-      any_http_url:
-        type: AnyHttpUrl
-        description: Any valid HTTP or HTTPS URL.
-        required: false
-      http_url:
-        type: HttpUrl
-        description: A valid HTTP or HTTPS URL.
-        required: false
-      any_websocket_url:
-        type: AnyWebsocketUrl
-        description: Any valid WebSocket or secure WebSocket URL.
-        required: false
-      websocket_url:
-        type: WebsocketUrl
-        description: A valid WebSocket or secure WebSocket URL.
-        required: false
-      file_url:
-        type: FileUrl
-        description: A valid file URL.
-        required: false
-      ftp_url:
-        type: FtpUrl
-        description: A valid FTP or FTPS URL.
-        required: false
-      postgres_dsn:
-        type: PostgresDsn
-        description: A valid PostgreSQL DSN.
-        required: false
-      cockroach_dsn:
-        type: CockroachDsn
-        description: A valid CockroachDB DSN.
-        required: false
-      amqp_dsn:
-        type: AmqpDsn
-        description: A valid AMQP DSN.
-        required: false
-      redis_dsn:
-        type: RedisDsn
-        description: A valid Redis DSN.
-        required: false
-      mongo_dsn:
-        type: MongoDsn
-        description: A valid MongoDB DSN.
-        required: false
-      kafka_dsn:
-        type: KafkaDsn
-        description: A valid Kafka DSN.
-        required: false
-      nats_dsn:
-        type: NatsDsn
-        description: A valid NATS DSN.
-        required: false
-      mysql_dsn:
-        type: MySQLDsn
-        description: A valid MySQL DSN.
-        required: false
-      mariadb_dsn:
-        type: MariaDBDsn
-        description: A valid MariaDB DSN.
-        required: false
-      clickhouse_dsn:
-        type: ClickHouseDsn
-        description: A valid ClickHouse DSN.
-        required: false
-      snowflake_dsn:
-        type: SnowflakeDsn
-        description: A valid Snowflake DSN.
-        required: false
-      email_str:
-        type: EmailStr
-        description: A valid email address.
-        required: false
-      name_email:
-        type: NameEmail
-        description: A valid name and email address.
-        required: false
-      ipvany_address:
-        type: IPvAnyAddress
-        description: A valid IPv4 or IPv6 address.
-        required: false
-"""
+    yasl = PYDANTIC_TYPES_YASL
     yaml_data = """
 id: test
 strict_bool: true
@@ -1168,34 +635,7 @@ task_list:
     run_eval_command(yaml_data, yasl, "list_of_tasks", True)
 
 def test_map_type_int_good():
-    yasl = """
-types:
-  task:
-    description: A thing to do.
-    namespace: dynamic
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
-  list_of_tasks:
-    description: A list of tasks to complete.
-    namespace: dynamic
-    properties:
-      task_list:
-        type: map[int, task]
-        description: A list of tasks to do.
-        required: true
-"""
+    yasl = TODO_INT_MAP_YASL
     yaml_data = """
 task_list:
   1:
@@ -1214,34 +654,7 @@ task_list:
     run_eval_command(yaml_data, yasl, "list_of_tasks", True)
 
 def test_map_type_bool_bad():
-    yasl = """
-types:
-  task:
-    description: A thing to do.
-    namespace: dynamic
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
-  list_of_tasks:
-    description: A list of tasks to complete.
-    namespace: dynamic
-    properties:
-      task_list:
-        type: map[bool, task]
-        description: A list of tasks to do.
-        required: true
-"""
+    yasl = TODO_BOOL_MAP_YASL
     yaml_data = """
 task_list:
   true:
@@ -1256,34 +669,7 @@ task_list:
     run_eval_command(yaml_data, yasl, "list_of_tasks", False)
 
 def test_map_type_bad():
-    yasl = """
-types:
-  task:
-    description: A thing to do.
-    namespace: dynamic
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
-  list_of_tasks:
-    description: A list of tasks to complete.
-    namespace: dynamic
-    properties:
-      task_list:
-        type: map[str, junk_task]
-        description: A list of tasks to do.
-        required: true
-"""
+    yasl = TODO_BAD_MAP_VALUE_YASL
     yaml_data = """
 task_list:
   task_01:
@@ -1298,41 +684,7 @@ task_list:
     run_eval_command(yaml_data, yasl, "list_of_tasks", False)
 
 def test_map_type_enum_key_good():
-    yasl = """
-types:
-  task:
-    description: A thing to do.
-    namespace: dynamic
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
-  list_of_tasks:
-    description: A list of tasks to complete.
-    namespace: dynamic
-    properties:
-      task_list:
-        type: map[taskkey, task]
-        description: A list of tasks to do.
-        required: true
-enums:
-  taskkey:
-    namespace: acme
-    description: The type of shape.
-    values:
-      - task_01
-      - task_02
-"""
+    yasl = TODO_ENUM_MAP_YASL
     yaml_data = """
 task_list:
   task_01:
@@ -1347,41 +699,7 @@ task_list:
     run_eval_command(yaml_data, yasl, "list_of_tasks", True)
 
 def test_map_type_enum_value_bad():
-    yasl = """
-types:
-  task:
-    description: A thing to do.
-    namespace: dynamic
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
-  list_of_tasks:
-    description: A list of tasks to complete.
-    namespace: dynamic
-    properties:
-      task_list:
-        type: map[taskkey, task]
-        description: A list of tasks to do.
-        required: true
-enums:
-  taskkey:
-    namespace: acme
-    description: The type of shape.
-    values:
-      - task_01
-      - task_02
-"""
+    yasl = TODO_ENUM_MAP_YASL
     yaml_data = """
 task_list:
   task_01:
@@ -1396,42 +714,7 @@ task_list:
     run_eval_command(yaml_data, yasl, "list_of_tasks", False)
 
 def test_map_nested_value_namespace_good():
-    yasl = """
-types:
-  task:
-    description: A thing to do.
-    namespace: something
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
-  list_of_tasks:
-    description: A list of tasks to complete.
-    namespace: dynamic
-    properties:
-      task_list:
-        type: map[other.taskkey, something.task]
-        description: A list of tasks to do.
-        required: true
-enums:
-  taskkey:
-    namespace: other
-    description: The type of task.
-    values:
-      - task_01
-      - task_02
-      - task_03
-"""
+    yasl = TODO_MIXED_NAMESPACE_YASL
     yaml_data = """
 task_list:
   task_01:
@@ -1450,50 +733,7 @@ task_list:
     run_eval_command(yaml_data, yasl, "list_of_tasks", True)
 
 def test_map_nested_value_good():
-    yasl = """
-types:
-  task:
-    description: A thing to do.
-    namespace: dynamic
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
-  feature:
-    description: A list of tasks to complete.
-    namespace: dynamic
-    properties:
-      feature:
-        type: str
-        description: The feature name.
-        required: true
-      task_list:
-        type: map[str, task]
-        description: A list of tasks to do.
-        required: true
-  project:
-    description: A project with tasks.
-    namespace: dynamic
-    properties:
-      project_name:
-        type: str
-        description: The name of the project.
-        required: true
-      features:
-        type: feature[]
-        description: The tasks for the project.
-        required: true
-"""
+    yasl = TODO_NESTED_MAP_YASL
     yaml_data = """
 project_name: Important Project
 features:
@@ -1511,21 +751,7 @@ features:
     run_eval_command(yaml_data, yasl, "project", True)
 
 def test_empty_markdown():
-    yasl = """
-types:
-  thing:
-    namespace: acme
-    description: Information about a thing.
-    properties:
-      id:
-        type: str
-        description: The unique identifier for the thing.
-        required: true
-      markdown:
-        type: markdown
-        description: A markdown value
-        required: true
-"""
+    yasl = MARKDOWN_YASL
     yaml_data = """
 id: test
 markdown: ""
@@ -1533,34 +759,7 @@ markdown: ""
     run_eval_command(yaml_data, yasl, "thing", False)
 
 def test_namespace_refs_bad():
-    yasl = """
-types:
-  task:
-    description: A thing to do.
-    namespace: main
-    properties:
-      description:
-        type: str
-        description: A description of the task.
-        required: true
-      owner:
-        type: str
-        description: The person responsible for the task.
-        required: false
-      complete:
-        type: bool
-        description: Is the task finished? True if yes, false if no.
-        required: true
-        default: false
-  list_of_tasks:
-    description: A list of tasks to complete.
-    namespace: other
-    properties:
-      task_list:
-        type: map[int, notmain.task]
-        description: A list of tasks to do.
-        required: true
-"""
+    yasl = TASK_BAD_NAMESPACE_REF_YASL
     yaml_data = """
 task_list:
   1:

--- a/uv.lock
+++ b/uv.lock
@@ -528,7 +528,7 @@ wheels = [
 
 [[package]]
 name = "yaml-tools"
-version = "0.2.4"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
Closes #33 

Pulls namespace out of enum and type definitions.
Restructures root of yasl schema (hence minor version bump due to significant change).

Now every type and enum must have a defined namespace in the schema definition.
Usage when referencing enums and types (in property.type, maps, and refs) is unchanged.