### PR TITLE
Dot in Namespace

### DIFF
--- a/features/data/todo.yasl
+++ b/features/data/todo.yasl
@@ -9,7 +9,7 @@ metadata:
     - tasks
     - example
 definitions:
-  dynamic:
+  acme.dynamic:
     types:
       task:
         description: A thing to do.
@@ -33,7 +33,7 @@ definitions:
         description: A list of tasks to complete.
         properties:
           task_list:
-            type: map[acme.taskkey, dynamic.task]
+            type: map[acme.taskkey, acme.dynamic.task]
             description: A list of tasks to do.
             required: true
     enums:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yaml-tools"
-version = "0.3.0"
+version = "0.3.1"
 description = "A suite of tools to advance your usage of yaml.  YASL provides schema definition and verification.  YAQL let's you query your yalm as if it were a database.  YARL provides analysis and reporting.  And YATL allows you to transform yaml from one structure (schema) to another."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/yasl/core.py
+++ b/src/yasl/core.py
@@ -372,7 +372,7 @@ def gen_pydantic_type_models(namespace: str, type_defs: Dict[str, TypeDef]):
 
                 # make sure map value is a known type
                 if "." in value_type_lookup:
-                    value_type_lookup_namespace, value_type_lookup = value_type_lookup.rsplit(".")
+                    value_type_lookup_namespace, value_type_lookup = value_type_lookup.rsplit(".", 1)
                 if value_type_lookup in type_map:
                     py_type = type_map[value_type_lookup]
                 elif registry.get_enum(value_type_lookup, value_type_lookup_namespace, namespace) is not None:

--- a/tests/yasl/schema_data.py
+++ b/tests/yasl/schema_data.py
@@ -796,3 +796,51 @@ definitions:
                         description: A list of tasks to do.
                         required: true
 """
+
+TODO_DOT_NAMESPACE_YASL = """
+metadata:
+  author: John Doe
+  date: 2024-06-15
+  description: A schema for managing a to-do list with tasks.
+  license: MIT
+  version: 1.0.0
+  tags:
+    - todo
+    - tasks
+    - example
+definitions:
+  acme.dynamic:
+    types:
+      task:
+        description: A thing to do.
+        properties:
+          description:
+            type: str
+            description: A description of the task.
+            required: true
+          owner:
+            type: str
+            description: The person responsible for the task.
+            required: false
+          complete:
+            type: bool
+            description: Is the task finished? True if yes, false if no.
+            required: true
+            default: false
+  acme:
+    types:
+      list_of_tasks:
+        description: A list of tasks to complete.
+        properties:
+          task_list:
+            type: map[acme.taskkey, acme.dynamic.task]
+            description: A list of tasks to do.
+            required: true
+    enums:
+      taskkey:
+        description: The type of shape.
+        values:
+          - task_01
+          - task_02
+          - task_03
+"""

--- a/tests/yasl/test_yasl.py
+++ b/tests/yasl/test_yasl.py
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 from yasl import yasl_eval
 from yasl.cli import main as yasl_cli_main
 
-from schema_data import MARKDOWN_YASL, PERSON_WEBSITE_REACHABLE_YAML, PYDANTIC_TYPES_YASL, TASK_BAD_NAMESPACE_REF_YASL, TODO_BAD_MAP_VALUE_YASL, TODO_BOOL_MAP_YASL, TODO_ENUM_MAP_YASL, TODO_INT_MAP_YASL, TODO_MIXED_NAMESPACE_YASL, TODO_NESTED_MAP_YASL, TODO_YASL, PERSON_YASL, SHAPE_YASL, CUSTOMER_LIST_YASL, NAMESPACE_CUSTOMER_LIST_YASL
+from schema_data import MARKDOWN_YASL, PERSON_WEBSITE_REACHABLE_YAML, PYDANTIC_TYPES_YASL, TASK_BAD_NAMESPACE_REF_YASL, TODO_BAD_MAP_VALUE_YASL, TODO_BOOL_MAP_YASL, TODO_DOT_NAMESPACE_YASL, TODO_ENUM_MAP_YASL, TODO_INT_MAP_YASL, TODO_MIXED_NAMESPACE_YASL, TODO_NESTED_MAP_YASL, TODO_YASL, PERSON_YASL, SHAPE_YASL, CUSTOMER_LIST_YASL, NAMESPACE_CUSTOMER_LIST_YASL
 
 def run_cli(args):
     filtered_args = [item for item in args if item is not None]
@@ -781,3 +781,22 @@ def test_default_namespace():
     yasl_path = "./features/data/ambiguous_ns/todo01.yasl"
     yaml_path = "./features/data/ambiguous_ns/todo.yaml"
     run_eval_command_with_paths(str(Path(yaml_path).absolute()), str(Path(yasl_path).absolute()), "task_list", True)
+
+def test_dot_in_namespace():
+    yasl = TODO_DOT_NAMESPACE_YASL
+    yaml_data= """
+task_list:
+  task_01:
+    description:  Buy coffee.
+    owner: Jim
+    complete: false
+  task_02:
+    description: Lead morning standup.
+    owner: Jim
+    complete: false
+  task_03:
+    description: Refine Backlog.
+    owner: Jim
+    complete: false
+"""
+    run_eval_command(yaml_data, yasl, "list_of_tasks", True)


### PR DESCRIPTION
Allow a namespace to contain "." (i.e. 'acme.core', 'acme.dynamic', etc.).